### PR TITLE
Add blog: Anthropic AI Academy: Claude を体系的に学べる無料公式コース

### DIFF
--- a/content/posts/2026-03-14-anthropic-ai-academy.md
+++ b/content/posts/2026-03-14-anthropic-ai-academy.md
@@ -1,0 +1,70 @@
+---
+title: "Anthropic AI Academy: Claude を体系的に学べる無料公式コース"
+date: 2026-03-14
+lastmod: 2026-03-14
+draft: false
+source_url: "https://github.com/hdknr/blogs/issues/1#issuecomment-4061231014"
+categories: ["AI/LLM"]
+tags: ["anthropic", "claude", "claude-code", "mcp", "agent"]
+---
+
+Anthropic が公式の学習プラットフォーム「**Anthropic Academy**」を無料公開しました。Claude Code、API、MCP、エージェントスキルなど、13コースが完全無料で受講でき、修了証も取得可能です。
+
+## Anthropic Academy とは
+
+[Anthropic Academy](https://anthropic.skilljar.com/) は、Anthropic が提供する公式のセルフペース学習プラットフォームです。AI の基礎から本番レベルの API 開発まで、3つのラーニングトラックで構成されています。
+
+- **登録**: メールアドレスのみ（クレジットカード不要）
+- **費用**: 完全無料
+- **修了証**: コース完了時に取得可能（LinkedIn プロフィールに追加可）
+
+## 3つのラーニングトラック
+
+### 1. AI Fluency（AI リテラシー）
+
+コードを書かずに AI を理解したい人向けのトラックです。
+
+- **Claude 101** — Claude の基本機能とプロンプティングの基礎
+- **AI Fluency: Framework & Foundations** — AI の中核概念を学ぶ
+- **AI Fluency for educators** — 教育者向け
+- **AI Fluency for students** — 学生向け
+- **AI Fluency for nonprofits** — 非営利団体向け
+- **Teaching AI Fluency** — インストラクター向けの教授法
+
+### 2. Product Training（プロダクト連携）
+
+Claude を業務ワークフローに組み込みたいプロフェッショナル向けです。
+
+- **Claude with Amazon Bedrock** — AWS プラットフォームでの統合
+- **Claude with Google Cloud's Vertex AI** — Google Cloud での統合
+
+### 3. Developer Deep-Dives（開発者向け）
+
+エンジニア向けの実践的なコースです。
+
+- **Claude Code in Action** — Claude Code の実践的な使い方、Skills の作成・配布
+- **Building with the Claude API** — システムプロンプト、ツール利用、コンテキストウィンドウ、アーキテクチャなどを8時間以上で網羅
+- **Introduction to Model Context Protocol** — MCP の入門、Python でのサーバー・クライアント構築
+- **Model Context Protocol: Advanced Topics** — MCP の本番パターン
+- **Introduction to agent skills** — エージェントスキルの基礎、MCP やサブエージェントとの組み合わせ
+
+## おすすめの受講順
+
+Claude Code をこれから本格的に使いたい開発者には、以下の順番がおすすめです。
+
+1. **Claude 101** で基本を押さえる
+2. **Building with the Claude API** で API の仕組みを理解する
+3. **Claude Code in Action** で実践的な使い方を学ぶ
+4. **Introduction to Model Context Protocol** → **Advanced Topics** で MCP を習得する
+5. **Introduction to agent skills** でエージェント開発に進む
+
+## 補足リソース
+
+Anthropic は Academy とは別に、API の基礎、プロンプトエンジニアリング、評価、ツール利用をカバーする Jupyter ノートブックのオープンソースリポジトリも公開しています。また、DeepLearning.AI との共同コース「[Agent Skills with Anthropic](https://learn.deeplearning.ai/courses/agent-skills-with-anthropic/)」も無料で受講可能です。
+
+## まとめ
+
+以前なら有料講座でしか学べなかった内容が、Anthropic の公式コースとして無料で体系的に学べるようになりました。特に Claude Code、MCP、エージェントスキルといった最新の開発ツールを学びたい人にとって、最初に取り組むべきリソースです。
+
+- 公式サイト: [anthropic.skilljar.com](https://anthropic.skilljar.com/)
+- 学習ガイド: [anthropic.com/learn](https://www.anthropic.com/learn)


### PR DESCRIPTION
## Summary
- 新規ブログ記事: Anthropic AI Academy: Claude を体系的に学べる無料公式コース
- ファイル: content/posts/2026-03-14-anthropic-ai-academy.md
- ソース: https://github.com/hdknr/blogs/issues/1#issuecomment-4061231014

🤖 Generated with [Claude Code](https://claude.com/claude-code)