### PR TITLE
Add blog: Qwen3.5-27B：個人PCで動く高性能LLMの実力と使い方

### DIFF
--- a/content/posts/2026-03-09-qwen35-27b.md
+++ b/content/posts/2026-03-09-qwen35-27b.md
@@ -1,0 +1,97 @@
+---
+title: "Qwen3.5-27B：個人PCで動く高性能LLMの実力と使い方"
+date: 2026-03-09
+lastmod: 2026-03-09
+draft: false
+source_url: "https://github.com/hdknr/blogs/issues/1#issuecomment-4026486965"
+categories: ["AI/LLM"]
+tags: ["qwen", "llm", "ollama"]
+---
+
+Alibaba Cloud の Qwen チームが 2026 年 2 月にリリースした **Qwen3.5-27B** は、27B パラメータという中規模サイズながら上位モデルに匹敵する性能を発揮する密（dense）モデルです。メモリ効率に優れ、量子化を活用すれば個人の PC でも快適に動作するため「自分専用 AI」を構築するのに最適な選択肢として注目されています。
+
+## Qwen3.5-27B の主な特徴
+
+### アーキテクチャ
+
+Qwen3.5-27B は MoE（Mixture of Experts）ではなく、全パラメータが推論時に活性化される **密モデル（dense model）** です。Gated Delta Networks と Feed Forward Networks を組み合わせた構造で、高い計算密度を実現しています。
+
+- **パラメータ数**: 27B（全パラメータ活性化）
+- **コンテキスト長**: 262K トークン（最大 1M まで拡張可能）
+- **対応言語**: 201 言語
+- **マルチモーダル**: 視覚・言語の統合能力を搭載
+
+### ベンチマーク性能
+
+27B というサイズにもかかわらず、主要ベンチマークで際立った成績を残しています。
+
+| ベンチマーク | スコア |
+|---|---|
+| MMLU-Pro | 86.1% |
+| GPQA Diamond | 85.5% |
+| SWE-bench Verified | 72.4% |
+| LiveCodeBench | 80.7% |
+| IFEval | 95.0% |
+| HMMT（数学） | 92.0% |
+
+特に **SWE-bench Verified で 72.4%** は GPT-5 mini と同等の数値であり、オープンウェイトの 27B 密モデルとしては驚異的な結果です。コーディング、数学、指示追従の各タスクで中規模モデルカテゴリをリードしています。
+
+## ローカル環境での実行
+
+Qwen3.5-27B の魅力は、個人の PC でローカル実行できる点にあります。
+
+### VRAM 要件の目安
+
+| 量子化方式 | モデルサイズ | 必要 VRAM |
+|---|---|---|
+| Q4_K_M（4bit） | 約 16.7 GB | 約 18 GB |
+| Q8_0（8bit） | 約 30 GB | 約 32 GB |
+| FP16（非量子化） | 約 54 GB | 約 56 GB |
+
+**Q4_K_M 量子化であれば RTX 4090（24GB）に収まります。** RTX 3090 でも 5bit 量子化で実用的に動作するという報告があります。
+
+### Ollama での実行
+
+Ollama を使えば手軽にローカル実行できます。
+
+```bash
+# Qwen3.5-27B をダウンロードして実行
+ollama run qwen3.5:27b
+```
+
+### llama.cpp での実行
+
+GGUF 形式のモデルを llama.cpp で直接実行する方法もあります。
+
+```bash
+# Hugging Face から GGUF モデルをダウンロード
+# Q4_K_M 版は約 16.7GB
+huggingface-cli download unsloth/Qwen3.5-27B-GGUF \
+  --include "Qwen3.5-27B-Q4_K_M.gguf" --local-dir ./models
+
+# llama.cpp で実行
+./llama-server -m ./models/qwen3.5-27b-q4_k_m.gguf \
+  -c 8192 -ngl 99
+```
+
+## 他のモデルとの比較
+
+Qwen3.5 シリーズには複数のバリアントがあり、用途に応じて選択できます。
+
+| モデル | パラメータ | 特徴 |
+|---|---|---|
+| Qwen3.5-27B | 27B（dense） | バランス型、ローカル向き |
+| Qwen3.5-35B-A3B | 35B（MoE、3B活性化） | 超軽量、速度重視 |
+| Qwen3.5-122B-A10B | 122B（MoE、10B活性化） | 高性能、API向き |
+
+27B は「全パラメータ活性化による高い品質」と「個人 PC で動くサイズ」のバランスが取れたモデルです。
+
+## まとめ
+
+Qwen3.5-27B は、SWE-bench Verified で GPT-5 mini に匹敵するスコアを出しながら、4bit 量子化で RTX 4090 に収まるという「コスパの鬼」です。ローカル LLM で本格的な開発支援やテキスト生成を行いたいなら、有力な選択肢になるでしょう。
+
+## 参考リンク
+
+- [Qwen3.5-27B - Hugging Face](https://huggingface.co/Qwen/Qwen3.5-27B)
+- [Qwen3.5 ローカル実行ガイド - Unsloth](https://unsloth.ai/docs/models/qwen3.5)
+- [Ollama - qwen3.5:27b](https://ollama.com/library/qwen3.5:27b)


### PR DESCRIPTION
## Summary
- 新規ブログ記事: Qwen3.5-27B：個人PCで動く高性能LLMの実力と使い方
- ファイル: content/posts/2026-03-09-qwen35-27b.md
- ソース: https://github.com/hdknr/blogs/issues/1#issuecomment-4026486965

🤖 Generated with [Claude Code](https://claude.com/claude-code)