### PR TITLE
Integrate aegis security scan into blog fact-checking (#114)

### DIFF
--- a/.claude/skills/blog/SKILL.md
+++ b/.claude/skills/blog/SKILL.md
@@ -142,7 +142,11 @@ tags: ["tag1", "tag2"]
      ```bash
      gh api /repos/{owner}/{repo} --jq '.full_name' 2>&1
      ```
-   - 公式サイトの URL がある場合、WebFetch でアクセスできるか確認する
+   - 公式サイトの URL がある場合、`aegis_fetch` ツールでセキュリティスキャン付きフェッチを行う
+     - verdict が "allow" → そのまま使用
+     - verdict が "warn" → ユーザーに警告を表示して確認を求める
+     - verdict が "block" → その URL を記事から除外し、ユーザーに報告
+     - aegis が利用できない場合（MCP 未接続等）は、WebFetch にフォールバックする
 
 2. **コマンド・APIの正確性**
    - 記事に記載されているインストールコマンドや CLI コマンドが正しい構文か

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ resources/_gen/
 .hugo_build.lock
 .secrets
 .claude/worktrees/
+.mcp.json


### PR DESCRIPTION
## Summary
- ブログ記事ファクトチェック時の外部 URL フェッチに aegis セキュリティスキャンを統合
- `WebFetch` → `aegis_fetch` MCP ツールに切り替え（verdict: allow/warn/block で処理分岐）
- aegis 未接続時は WebFetch にフォールバック
- `.mcp.json`（ローカル MCP 設定）を `.gitignore` に追加

## 変更ファイル
- `.claude/skills/blog/SKILL.md` — ファクトチェックセクションの URL 検証方法を変更
- `.gitignore` — `.mcp.json` を除外対象に追加

## 前提条件
- aegis 環境の起動が必要（`cd ~/Projects/hdknr/aegis && docker compose up -d`）
- `.mcp.json` はローカルに手動作成が必要（ローカルパスを含むため git 管理外）

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)