### PR TITLE
Add blog: Mistral Voxtral TTS: ElevenLabs に匹敵するオープンウェイト音声AI

### DIFF
--- a/content/posts/2026/03/2026-03-30-mistral-voxtral-tts.md
+++ b/content/posts/2026/03/2026-03-30-mistral-voxtral-tts.md
@@ -1,0 +1,69 @@
+---
+title: "Mistral Voxtral TTS: ElevenLabs に匹敵するオープンウェイト音声AI"
+date: 2026-03-30
+lastmod: 2026-03-30
+draft: false
+description: "Mistral AI が公開した Voxtral TTS は 4B パラメータのオープンウェイト音声合成モデル。ElevenLabs 級の品質をローカル GPU で実現。動作要件・音声クローン機能・ライセンスを解説。"
+source_url: "https://github.com/hdknr/blogs/issues/1#issuecomment-4158762368"
+categories: ["AI/LLM"]
+tags: ["Mistral", "TTS", "音声合成", "オープンウェイト", "Voxtral"]
+---
+
+Mistral AI が 2026年3月26日にリリースした **Voxtral TTS**（Text-to-Speech）は、オープンウェイトで公開された音声合成モデルです。ElevenLabs に匹敵する品質を持ちながら、ローカル環境で動作するのが最大の特徴です。
+
+## Voxtral TTS の概要
+
+Voxtral TTS は Mistral AI 初のテキスト読み上げモデルで、4B（40億）パラメータの軽量設計です。Hugging Face で `mistralai/Voxtral-4B-TTS-2603` として公開されています。
+
+主な特徴:
+
+- **オープンウェイト**: モデル重みが公開されており、自社サーバーやローカル PC で実行可能
+- **9言語対応**: 英語、フランス語、ドイツ語、スペイン語、オランダ語、ポルトガル語、イタリア語、ヒンディー語、アラビア語（日本語は未対応）
+- **低遅延**: 500文字・10秒のサンプルに対して TTFA（Time-to-First-Audio）90ms
+- **リアルタイム性能**: RTF（Real-Time Factor）6x、つまりリアルタイムの約6倍の速度で生成（10秒のクリップを約1.6秒で出力）
+- **音声クローン**: わずか3秒のサンプルからアクセント・抑揚・話し方の癖を再現
+- **20種類のプリセット音声**: すぐに使える多様な声質
+
+## ElevenLabs との比較
+
+Mistral の公式ベンチマークによると、Voxtral TTS は:
+
+- **ElevenLabs Flash v2.5** より優れた自然さを実現（同等の TTFA を維持）
+- **ElevenLabs v3** と同等の音質を達成
+
+従来は従量課金制の商用サービスに頼るしかなかった高品質音声合成が、オープンウェイトで利用できるようになりました。
+
+## 動作要件
+
+| 項目 | 仕様 |
+|------|------|
+| パラメータ数 | 4B |
+| モデルサイズ | 約 8 GB（BF16） |
+| GPU メモリ | 16 GB 以上推奨 |
+| 出力形式 | WAV, PCM, FLAC, MP3, AAC, Opus |
+| サンプリングレート | 24 kHz |
+
+BF16 版は GPU 16GB 以上が必要ですが、量子化バージョン（`mlx-community/Voxtral-4B-TTS-2603-mlx-4bit`）も公開されており、Apple Silicon Mac などでより少ないメモリで実行可能です。Mistral はスマートフォンなどのエッジデバイスでの動作も想定した設計としています。
+
+## 利用シーン
+
+- **ボイスエージェント**: カスタマーサポートや社内チャットボットの音声応答
+- **コンテンツ制作**: ポッドキャスト・ナレーション・動画の音声生成
+- **多言語対応**: 音声クローンが言語切り替え時にも声の特徴を保持するため、吹き替えやリアルタイム翻訳に有効
+- **プライバシー重視の用途**: 音声データを外部 API に送信せずオンプレミスで処理可能
+
+## ライセンスと注意点
+
+Voxtral TTS は **CC BY-NC 4.0**（クリエイティブ・コモンズ 表示-非営利 4.0）ライセンスで公開されています。商用利用には別途ライセンスが必要です。
+
+また、API 経由での利用も可能で、Mistral の Le Chat や la Plateforme から利用できます。
+
+## まとめ
+
+Voxtral TTS は、高品質な音声合成がオープンウェイトとして誰でもローカルで動かせる時代を切り開くモデルです。商用 TTS サービスへの依存を減らしたい開発者や、プライバシーを重視する企業にとって有力な選択肢になるでしょう。
+
+## 参考リンク
+
+- [Speaking of Voxtral（Mistral 公式ブログ）](https://mistral.ai/news/voxtral-tts)
+- [Voxtral-4B-TTS-2603（Hugging Face）](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603)
+- [Voxtral TTS Demo（Hugging Face Spaces）](https://huggingface.co/spaces/mistralai/voxtral-tts-demo)


### PR DESCRIPTION
## Summary

- Mistral AI の Voxtral TTS（4B パラメータのオープンウェイト音声合成モデル）を紹介する記事
- ElevenLabs との比較、動作要件、利用シーン、ライセンス情報をカバー
- ソース: https://github.com/hdknr/blogs/issues/1#issuecomment-4158762368
