### PR TITLE
Add blog: CVE-2026-32746: GNU Inetutils telnetd に32年間潜んでいた認証前リモートコード実行の脆弱性

### DIFF
--- a/content/posts/2026/03/2026-03-18-cve-2026-32746-telnetd.md
+++ b/content/posts/2026/03/2026-03-18-cve-2026-32746-telnetd.md
@@ -1,0 +1,110 @@
+---
+title: "CVE-2026-32746: GNU Inetutils telnetd に32年間潜んでいた認証前リモートコード実行の脆弱性"
+date: 2026-03-18
+lastmod: 2026-03-18
+draft: false
+source_url: "https://github.com/hdknr/blogs/issues/1#issuecomment-4085469147"
+categories: ["セキュリティ"]
+tags: ["security", "linux", "CVE", "telnet", "バッファオーバーフロー"]
+description: "GNU Inetutils telnetd の認証前リモートコード実行脆弱性 CVE-2026-32746（CVSS 9.8）の技術的詳細、攻撃手法、パッチ状況、対策を解説。"
+---
+
+GNU Inetutils の telnetd デーモンに、CVSS 9.8 の深刻なバッファオーバーフロー脆弱性 **CVE-2026-32746** が発見された。1994年から存在していたこのバグは、認証前のリモートコード実行（Pre-Auth RCE）を可能にする。telnetd を公開サーバーで運用している管理者は直ちに対応が必要だ。
+
+## 脆弱性の概要
+
+| 項目 | 内容 |
+|------|------|
+| CVE ID | CVE-2026-32746 |
+| CVSS スコア | 9.8（Critical） |
+| 影響範囲 | GNU Inetutils 2.7 以前の全バージョン |
+| 脆弱性の種類 | BSS ベースのバッファオーバーフロー（境界外書き込み） |
+| 攻撃条件 | 認証不要・リモートから実行可能 |
+| 発見者 | イスラエルのサイバーセキュリティ企業 Dream（技術解析: watchTowr Labs） |
+| 報告日 | 2026年3月11日 |
+
+## 技術的な詳細
+
+### 脆弱な箇所
+
+脆弱性は LINEMODE SLC（Set Local Characters）サブオプションハンドラの `add_slc` 関数に存在する。telnetd はクライアントから送られた SLC トリプレット（3バイト組）を固定サイズのバッファ `slcbuf`（0x6C バイト）に格納する。この際、**境界チェックを一切行っていない**。
+
+```c
+// 境界チェックなしでバッファに書き込む脆弱なコード
+if ((*slcptr++ = (unsigned char) func) == 0xff)
+  *slcptr++ = 0xff;
+
+if ((*slcptr++ = (unsigned char) flag) == 0xff)
+  *slcptr++ = 0xff;
+
+if ((*slcptr++ = (unsigned char) val) == 0xff)
+  *slcptr++ = 0xff;
+```
+
+### 攻撃の仕組み
+
+Telnet の接続確立時に行われるオプションネゴシエーション（機能交渉）中に、特別に細工されたパケットを送信することで攻撃が成立する。具体的には以下のプロトコルフォーマットを悪用する:
+
+```
+IAC SB LINEMODE LM_SLC <トリプレット群> IAC SE
+(0xFF 0xFA 0x22 <トリプレット群> 0xFF 0xF0)
+```
+
+この脆弱なパスは **Telnet の認証が完了する前**、つまりログインプロンプトが表示される前の接続ハンドシェイク中に到達可能である。攻撃者は約400バイトの隣接変数を破壊できる。具体的には `slcptr`（バッファポインタ）や `def_slcbuf`（遅延 SLC バッファへのポインタ）を上書きし、任意コード実行につなげられる。
+
+### 悪用の制約
+
+脆弱性の悪用にはいくつかの制約がある:
+
+- **func バイト制限**: NSLC（0x1e）を超える値は拒否されゼロに置換される
+- **0xFF バイトのエスケープ**: 0xFF は 0xFF 0xFF にダブリングされる
+- **パケットサイズ制限**: サブネゴシエーションパケットは最大 0x200 バイト
+
+これらの制約により実用的なエクスプロイト開発は容易ではないが、`def_slcbuf` ポインタの破壊を経由して `free()` の任意アドレス呼び出しに持ち込む攻撃パスが研究者によって実証されている。
+
+## パッチ状況
+
+- GNU inetutils のソースリポジトリにはパッチがコミット済み
+- パッチは最小限の修正で、オーバーフロー発生時にデータを無視する方式
+- **多くの Linux ディストリビューションはまだパッチを配布していない**（2026年3月時点）
+- Debian sid/forky のみが修正を含むパッケージを配布
+
+## 対策
+
+### 最優先: telnet サービスの無効化
+
+最も確実な対策は **telnet サービスを完全に無効化し、SSH に移行する**ことである。telnet は通信が暗号化されないため、この脆弱性の有無にかかわらずセキュリティ上のリスクがある。
+
+```bash
+# telnetd が動作しているか確認
+systemctl status inetutils-telnetd
+
+# 無効化
+sudo systemctl stop inetutils-telnetd
+sudo systemctl disable inetutils-telnetd
+```
+
+### パッチ適用
+
+ディストリビューションからパッチが提供され次第、速やかに適用する。
+
+### ネットワークレベルの緩和策
+
+telnet サービスをすぐに停止できない場合は、ファイアウォールでポート23へのアクセスを信頼できるネットワークに限定する。
+
+```bash
+# ufw の場合
+sudo ufw deny 23/tcp
+sudo ufw allow from 192.168.1.0/24 to any port 23 proto tcp
+```
+
+## まとめ
+
+CVE-2026-32746 は、32年間にわたって GNU Inetutils の telnetd に潜んでいた深刻な脆弱性である。認証前にリモートからコード実行が可能という点で、インターネットに公開された telnetd サービスにとっては致命的なリスクとなる。telnet はレガシープロトコルであり、この機会に SSH への完全移行を検討すべきである。
+
+## 参考リンク
+
+- [watchTowr Labs - A 32-Year-Old Bug Walks Into A Telnet Server](https://labs.watchtowr.com/a-32-year-old-bug-walks-into-a-telnet-server-gnu-inetutils-telnetd-cve-2026-32746/)
+- [The Hacker News - Critical Unpatched Telnetd Flaw](https://thehackernews.com/2026/03/critical-telnetd-flaw-cve-2026-32746.html)
+- [CyCognito Blog - Emerging Threat: CVE-2026-32746](https://www.cycognito.com/blog/emerging-threat-gnu-inetutils-telnetd-linemode-slc-buffer-overflow-cve-2026-32746/)
+- [GitHub PoC - jeffaf/cve-2026-32746](https://github.com/jeffaf/cve-2026-32746)


### PR DESCRIPTION
## Summary

- GNU Inetutils telnetd のバッファオーバーフロー脆弱性 CVE-2026-32746（CVSS 9.8）についての解説記事
- 技術的な詳細（LINEMODE SLC ハンドラの境界チェック欠如）、パッチ状況、対策を網羅
- ソース: https://github.com/hdknr/blogs/issues/1#issuecomment-4085469147
