### PR TITLE
Add blog: 6ヶ月でAIエンジニアになるロードマップ — 無料リソースだけで学ぶ完全ガイド

### DIFF
--- a/content/posts/2026/03/2026-03-18-ai-engineer-6-months-roadmap.md
+++ b/content/posts/2026/03/2026-03-18-ai-engineer-6-months-roadmap.md
@@ -1,0 +1,128 @@
+---
+title: "6ヶ月でAIエンジニアになるロードマップ — 無料リソースだけで学ぶ完全ガイド"
+date: 2026-03-18
+lastmod: 2026-03-18
+draft: false
+source_url: "https://github.com/hdknr/blogs/issues/1#issuecomment-4079195726"
+categories: ["AI/LLM"]
+tags: ["キャリア", "機械学習", "Python", "LLM", "ディープラーニング"]
+description: "Python基礎から機械学習、ディープラーニング、LLM/RAG開発、MLOpsまで。6ヶ月でAIエンジニアになるための学習ロードマップを、MIT・Stanford・Harvardの無料コースで構成。"
+---
+
+この記事では、Python基礎からLLM/RAG開発、MLOpsまでを6ヶ月で学ぶロードマップを、すべて無料のリソースで紹介する。各月のゴールと具体的な教材リスト付き。
+
+AIエンジニアの求人は前年比143%増加している。米国での平均年収は約17万5,000ドル。インドでは10件の求人に対して1人しか適格な候補者がいない状況だ。
+
+学位は不要。ブートキャンプも不要。必要なスキルを学ぶためのリソースはすべて無料で公開されている。この記事では、AI分野のコンテンツクリエイターであるNav Toor氏が提唱する6ヶ月のロードマップを紹介する。1ヶ月ずつ、6つのフェーズで構成されている。
+
+## Month 1: Python とプログラミング基礎
+
+すべてのAIフレームワーク、ライブラリ、ツールはPythonの上に構築されている。このステップを省略したり、急いで済ませたりしてはいけない。
+
+**学ぶべき内容:** 変数、関数、ループ、条件分岐、データ構造（リスト、辞書、セット）、オブジェクト指向プログラミング、ファイル操作、エラー処理、Git/GitHub の基本。
+
+### リソース
+
+- **Python for Everybody（Dr. Chuck, ミシガン大学）** — YouTubeとCourseraで無料公開。史上最も人気のあるPythonコース
+- **CS50P: Introduction to Programming with Python（Harvard, David Malan）** — YouTube で無料。ハーバード品質、前提知識不要
+- **Automate the Boring Stuff with Python（Al Sweigart）** — オンラインで無料閲覧可能。初日から実践的なPython
+- **Git and GitHub for Beginners（freeCodeCamp）** — YouTube で無料。1時間で必要な知識をカバー
+
+**マイルストーン:** CSVを読み込み、データを処理し、結果を出力するPythonスクリプトを書ける。GitHubアカウントに3つ以上のプロジェクトがプッシュされている。
+
+## Month 2: 数学と統計
+
+数学の学位は不要だ。モデルがなぜ動くのか、うまくいかないときにどう対処すべきかを理解できる程度の数学で十分だ。
+
+**学ぶべき内容:** 線形代数（ベクトル、行列、内積、固有値）、微積分（微分、勾配、連鎖律）、確率（ベイズの定理、分布）、統計（平均、分散、仮説検定、回帰）。
+
+### リソース
+
+- **3Blue1Brown: Essence of Linear Algebra** — YouTube で無料。16本の動画。史上最高の数学ビジュアルコンテンツ
+- **3Blue1Brown: Essence of Calculus** — YouTube で無料。同じクオリティと明快さ
+- **Khan Academy: Statistics and Probability** — 無料。包括的。自分のペースで学習可能
+- **MIT 18.06: Linear Algebra（Gilbert Strang）** — MIT OCW で無料。大学講義のゴールドスタンダード
+- **StatQuest with Josh Starmer** — YouTube で無料。専門用語なしで統計を解説
+
+**マイルストーン:** 勾配降下法を直感的に理解できる。損失関数の役割と、行列乗算がニューラルネットワークで重要な理由を説明できる。
+
+## Month 3: 機械学習の基礎
+
+モデル、トレーニング、予測、評価。ここからが本番だ。
+
+**学ぶべき内容:** 教師あり学習（回帰、分類）、教師なし学習（クラスタリング、次元削減）、モデル評価（精度、適合率、再現率、F1）、過学習、交差検証、特徴量エンジニアリング。ライブラリ: scikit-learn, pandas, NumPy, matplotlib。
+
+### リソース
+
+- **Stanford CS229: Machine Learning（Andrew Ng）** — YouTube で無料。現代のML教育運動を始めたコース。必修
+- **Google Machine Learning Crash Course** — 無料。インタラクティブ。Googleエンジニアが構築
+- **Kaggle Learn: Intro to ML + Intermediate ML + Feature Engineering** — 無料のマイクロコース。最初からハンズオン
+- **fast.ai: Practical Machine Learning for Coders** — 無料。トップダウンアプローチ。理論の前にまず作る
+
+**マイルストーン:** 実データセットで分類モデルを構築・学習・評価できる。きれいなREADME付きのMLプロジェクトが2つ以上GitHubにある。
+
+## Month 4: ディープラーニングとニューラルネットワーク
+
+画像認識、言語モデル、音声、生成 — すべての背後にあるアーキテクチャ。AIが本当にパワフルになるのはここからだ。
+
+**学ぶべき内容:** ニューラルネットワークの基礎（パーセプトロン、活性化関数、バックプロパゲーション）、CNN（画像タスク）、RNNとLSTM（シーケンスタスク）、Transformer（GPT, Claude, Gemini の基盤アーキテクチャ）。フレームワーク: PyTorch or TensorFlow。
+
+### リソース
+
+- **Stanford CS231n: CNNs for Visual Recognition** — YouTube で無料。コンピュータビジョンのスタンダードコース
+- **Stanford CS224n: NLP with Deep Learning** — YouTube で無料。NLPのスタンダードコース。Transformerを詳しくカバー
+- **MIT 6.S191: Introduction to Deep Learning** — YouTube で無料。ハイペース、毎年更新、最新アーキテクチャをカバー
+- **fast.ai: Practical Deep Learning for Coders** — 無料。最初のレッスンから実モデルを構築。PyTorchベース
+- **3Blue1Brown: Neural Networks** — YouTube で無料。4本の動画。ニューラルネットワークの学習過程を最も明快に視覚的に解説
+
+**マイルストーン:** PyTorchでニューラルネットワークを構築・学習できる。非技術者にセルフアテンションを説明できるほどTransformerを理解している。
+
+## Month 5: 生成AI、LLM、エージェント
+
+2026年にAIエンジニアを雇うすべての企業が求めているスキルセットがこれだ。
+
+**学ぶべき内容:** LLMの仕組み（トークナイゼーション、エンベディング、アテンション、推論）、プロンプトエンジニアリング、RAG（Retrieval-Augmented Generation）、ファインチューニング、LangChain と LlamaIndex、AIエージェント構築、ベクターデータベース（Pinecone, Weaviate, ChromaDB）、API統合（OpenAI, Anthropic, Google）。
+
+### リソース
+
+- **Andrej Karpathy: Let's build GPT: from scratch, in code, spelled out** — YouTube で無料。約2時間。元OpenAI研究者による、GPTの仕組みの最高の解説
+- **DeepLearning.AI: LangChain for LLM Application Development（Andrew Ng）** — 無料ショートコース。ハンズオン
+- **DeepLearning.AI: Building Systems with the ChatGPT API** — 無料ショートコース。LLMアプリの本番パターン
+- **Hugging Face NLP Course** — 無料。Transformer、ファインチューニング、デプロイメントをカバー。最高のオープンソースNLPリソース
+- **LlamaIndex Documentation and Tutorials** — 無料。RAGパイプラインのスタンダードフレームワーク
+
+**マイルストーン:** 自分のドキュメントから質問に回答するRAGアプリケーションを構築済み。少なくとも1つのLLMアプリをデプロイ済み。
+
+## Month 6: MLOps、デプロイメント、ポートフォリオ
+
+モデルの構築は仕事の20%。プロダクションに乗せ、稼働させ続け、動作を証明するのが残り80%だ。
+
+**学ぶべき内容:** Docker とコンテナ化、API開発（FastAPI, Flask）、クラウドデプロイメント（AWS, GCP, Azure の基本）、CI/CDパイプライン、モデルモニタリング、MLflowによる実験トラッキング、評価フレームワーク、コスト最適化。
+
+### リソース
+
+- **Made With ML（Goku Mohandas）** — 無料。利用可能な最も包括的なMLOpsコース。フルプロダクションパイプラインをカバー
+- **Docker for Beginners（TechWorld with Nana）** — YouTube で無料。実践的でわかりやすい
+- **FastAPI Documentation and Tutorial** — 無料。モデル用の本番品質APIを構築
+- **MLflow Documentation and Quickstart** — 無料。業界標準の実験トラッキング
+- **Full Stack Deep Learning（UC Berkeley）** — YouTube で無料。ML研究とプロダクションエンジニアリングの架け橋
+
+**マイルストーン:** GitHubに3〜5のエンドツーエンドプロジェクトがある。少なくとも1つはデプロイされて稼働中。LinkedInとポートフォリオでAIエンジニアリングスキルを明確にアピールしている。
+
+## 各月で作るべきもの
+
+- **Month 1-2:** データ分析スクリプト、Webスクレイパー、自動化ツール
+- **Month 3:** 実データセットでの予測モデル（住宅価格、顧客離脱、不正検知）
+- **Month 4:** 画像分類器またはセンチメント分析モデル（スクラッチからトレーニング）
+- **Month 5:** アップロードしたドキュメントから質問に答えるRAGチャットボット。マルチステップタスクを完了するAIエージェント
+- **Month 6:** クラウドにデプロイしたフルスタックAIアプリ。モニタリングと評価付きのエンドツーエンドパイプライン
+
+すべてのプロジェクトをGitHubに公開し、きれいなREADMEを付け、LinkedInに投稿する。これがポートフォリオであり、採用につながるものだ。
+
+## まとめ
+
+6ヶ月。1日2〜3時間。費用ゼロ。
+
+リソースはMIT、Stanford、Harvard、Google、そして日常的に使っているモデルを構築したエンジニアたちによるものだ。有料のブートキャンプでも、これ以上の内容は教えられない。多くはより質の低い内容を10,000ドルで売っている。
+
+このキャリアを手にするために必要なのは、6ヶ月の集中した努力だけだ。今日から始めよう。Month 1、Python からだ。


### PR DESCRIPTION
## Summary

- Nav Toor氏のX投稿を基に、6ヶ月でAIエンジニアになるための無料リソースロードマップ記事を作成
- Python基礎→数学→ML→ディープラーニング→LLM/RAG→MLOpsの6フェーズ構成
- MIT, Stanford, Harvard等の無料コースを網羅

## Source

https://github.com/hdknr/blogs/issues/1#issuecomment-4079195726

## Checklist

- [x] Hugo ビルド確認済み
- [x] ファクトチェック済み（主要リソースの存在確認）
- [x] tech-writer / seo-advisor レビュー反映済み
