### PR TITLE
Add blog: Claude Certified Architect試験 完全ガイド

### DIFF
--- a/content/posts/2026/03/2026-03-17-claude-certified-architect-exam-guide.md
+++ b/content/posts/2026/03/2026-03-17-claude-certified-architect-exam-guide.md
@@ -1,0 +1,102 @@
+---
+title: "Claude Certified Architect試験 完全ガイド"
+date: 2026-03-17
+lastmod: 2026-03-17
+draft: false
+source_url: "https://github.com/hdknr/blogs/issues/1#issuecomment-4078722052"
+categories: ["AI/LLM"]
+tags: ["Claude", "Anthropic", "資格", "認定試験", "アーキテクト"]
+---
+
+## はじめに
+
+2026年から、Anthropic が「Claude Certified Architect」という公式資格の提供を開始しました。これは Claude の実務活用能力を認定する初めての公式資格であり、AI エンジニアやアーキテクトにとって注目の認定制度です。
+
+本記事では、Claude Certified Architect 試験の概要や対策方法について解説します。
+
+## Claude Certified Architect とは
+
+「Claude Certified Architect」は、Anthropic が提供する Claude の実務活用能力を認定する公式資格です。Claude を使ったシステム設計・アーキテクチャ構築の能力を評価します。
+
+### 対象者
+
+- Claude API を活用したシステムを設計・開発するエンジニア
+- AI を組み込んだプロダクトを企画・設計するアーキテクト
+- 企業内で Claude 活用を推進するリーダー・コンサルタント
+
+### 試験の特徴
+
+- Anthropic 公式認定の資格
+- Claude の実務活用能力（設計・実装・運用）を総合的に評価
+- AI アーキテクチャ設計のベストプラクティスへの理解が問われる
+
+## 試験範囲（想定）
+
+Claude Certified Architect 試験では、以下のような領域が出題範囲として想定されます。
+
+### 1. Claude API の活用
+
+- Messages API の基本的な使い方
+- プロンプト設計（System Prompt、Human/Assistant ターン）
+- ストリーミングレスポンスの実装
+- ツール使用（Tool Use / Function Calling）
+
+### 2. アーキテクチャ設計
+
+- Claude を組み込んだシステムの設計パターン
+- RAG（Retrieval-Augmented Generation）アーキテクチャ
+- マルチエージェントシステムの設計
+- Claude とその他のサービス（データベース、外部 API）の連携
+
+### 3. セキュリティとコンプライアンス
+
+- プロンプトインジェクション対策
+- 機密情報の取り扱いと出力フィルタリング
+- 利用規約・ポリシーへの準拠
+
+### 4. パフォーマンスと最適化
+
+- レイテンシ・コスト最適化
+- プロンプトキャッシング（Prompt Caching）の活用
+- バッチ処理と非同期処理の設計
+
+### 5. モニタリングと運用
+
+- Claude を使ったシステムのモニタリング
+- エラーハンドリングとリトライ設計
+- ログ収集・分析によるシステム改善
+
+## 学習リソース
+
+試験対策に活用できる公式リソースを紹介します。
+
+### Anthropic 公式ドキュメント
+
+- [Anthropic API ドキュメント](https://docs.anthropic.com/) — API リファレンスと利用ガイド
+- [Claude のモデル概要](https://docs.anthropic.com/en/docs/about-claude/models) — 各モデルの特徴と選択基準
+- [プロンプトエンジニアリングガイド](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering) — 効果的なプロンプト設計
+
+### ハンズオン学習
+
+実際に Claude API を使ったプロダクト開発を通じて、設計・実装・運用の経験を積むことが最も効果的です。
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+message = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=1024,
+    messages=[
+        {"role": "user", "content": "Claude Certified Architect 試験の学習方法を教えてください。"}
+    ]
+)
+print(message.content)
+```
+
+## まとめ
+
+Claude Certified Architect は、Claude を使ったシステム設計の専門性を公式に証明できる資格です。AI 活用が加速する中で、こうした認定資格は実務能力の可視化に役立ちます。
+
+詳細情報は Anthropic の公式サイトや発表を随時チェックしてください。資格に関する最新情報が公開され次第、本記事も更新する予定です。


### PR DESCRIPTION
## 概要

X(Twitter) の投稿をもとに、Anthropic の公式資格「Claude Certified Architect」についての解説記事を作成しました。

- ソース: https://github.com/hdknr/blogs/issues/1#issuecomment-4078722052
- 対象日付: 2026-03-17

## 記事内容

- Claude Certified Architect 資格の概要
- 試験範囲（API活用・アーキテクチャ設計・セキュリティ・最適化・運用）
- 学習リソースの紹介
