### PR TITLE
Add blog: Claude CodeからShopifyストアを直接操作できる「Shopify AI Toolkit」

### DIFF
--- a/content/posts/2026/04/2026-04-12-claude-code-shopify-ai-toolkit.md
+++ b/content/posts/2026/04/2026-04-12-claude-code-shopify-ai-toolkit.md
@@ -1,0 +1,55 @@
+---
+title: "Claude CodeからShopifyストアを直接操作できる「Shopify AI Toolkit」"
+date: 2026-04-12
+lastmod: 2026-04-12
+draft: false
+source_url: "https://github.com/hdknr/blogs/issues/1#issuecomment-4230949842"
+categories: ["ツール/開発環境"]
+tags: ["Claude Code", "Shopify", "MCP", "AI", "EC"]
+---
+
+Shopifyが「Shopify AI Toolkit」を公開した。Claude Code、Codex、Cursor、VS Codeなどのエージェント・IDE から直接 Shopify ストアを管理できる仕組みだ。
+
+## Shopify AI Toolkit とは
+
+Shopify AI Toolkit は、AI エージェントや開発ツールから Shopify バックエンドへ直接アクセスできるようにするツールキットだ。Model Context Protocol（MCP）をベースにしており、対応クライアントであれば Claude Code を含む主要エージェントから利用できる。
+
+公式アナウンスでは以下の対応ツールが挙げられている:
+
+- **Claude Code**
+- OpenAI Codex
+- Cursor
+- VS Code
+- その他 MCP 対応エージェント
+
+## 主な機能
+
+ツイートで紹介されている主要機能は以下のとおり:
+
+- **バックエンドへの直接書き込み**: Claude Code などのエージェントから Shopify のバックエンド API へ直接書き込み操作が可能
+- **1プロンプトで一括操作**: 商品・注文・在庫・SEO・画像を単一のプロンプトで一括管理できる
+- **16スキル搭載**: 豊富な操作スキルが組み込み済み
+- **プラグイン経由で自動アップデート**: プラグイン機構により機能が自動的に最新化される
+
+## Claude Code での活用イメージ
+
+Claude Code から Shopify AI Toolkit を使うと、たとえば次のような操作がプロンプトひとつで実行できる:
+
+- 新商品の登録（タイトル・説明・価格・在庫数の一括設定）
+- SEO メタデータの一括最適化
+- 特定カテゴリの商品価格を一括変更
+- 注文ステータスの確認・更新
+
+従来は Shopify 管理画面を手動で操作するか、独自スクリプトを書く必要があったこれらの作業が、自然言語の指示だけで完結する。
+
+## Shopify 制作への応用
+
+チャエン氏（[@masahirochaen](https://x.com/masahirochaen)）のツイートでは「Shopify制作代行で起業できる」と言及されており、EC サイト構築・運用における AI エージェント活用の可能性が広がっている。
+
+エージェントが Shopify の全操作を担えるようになると、ストアの初期セットアップから日常的な在庫・価格管理まで、人手を介さず自動化する運用フローも現実的になってくる。
+
+## まとめ
+
+Shopify AI Toolkit は MCP 経由で AI エージェントと EC プラットフォームを直結する仕組みだ。Claude Code ユーザーにとっては、コード開発の延長線上で EC ストアの構築・運用まで行える環境が整いつつある。
+
+公式情報は [Shopify](https://shopify.com/) の発表を参照してほしい。

--- a/content/wiki/concepts/adaptive-thinking.md
+++ b/content/wiki/concepts/adaptive-thinking.md
@@ -1,0 +1,56 @@
+---
+title: "アダプティブ・シンキング（Claude の思考深度制御）"
+description: "Anthropic が導入した Claude の思考量を動的に調整する仕組み。ユーザーから「サイレント・ダウングレード」と批判され、/effort max で元の深度に戻せる"
+date: 2026-04-13
+lastmod: 2026-04-13
+aliases: ["adaptive thinking", "effort level", "claude thinking depth"]
+related_posts:
+  - "/posts/2026/04/claude-thinking-nerfed/"
+tags: ["claude", "claude-code", "思考深度", "Anthropic", "llm"]
+---
+
+## 概要
+
+Anthropic が Claude Code に導入した、タスクの複雑さに応じて思考量（extended thinking のトークン数）を自動調整する仕組み。AMD の AI ディレクターが 7,000 セッションのログ分析で思考深度の 67% 低下を発見し、「サイレント・ダウングレード」として SNS で大きな議論を呼んだ。
+
+## 発覚の経緯
+
+2026年4月2日、AMD シニア AI ディレクター Stella Laurenzo 氏が GitHub Issue（anthropics/claude-code#42796）を投稿。2026年1〜3月の約 6,852 セッション（234,760 ツールコール、17,871 思考ブロック）を分析した結果:
+
+| 指標 | 変更前（1月末〜2月中旬） | 変更後（3月8日〜23日） |
+|------|--------------------------|------------------------|
+| 思考の中央値（文字数） | 約 2,200 文字 | 約 600 文字（67% 減） |
+| 思考ブロックの割合 | 約 30% | 約 15% |
+
+## Anthropic の説明
+
+Anthropic は「アダプティブ・シンキング」と「エフォートレベルの変更」の2点を認めた。
+
+- **アダプティブ・シンキング**: タスクの複雑さを判断して思考量を動的に調整する仕組みを導入
+- **エフォートレベルの変更**: デフォルトの effort レベルを意図的に下げた
+
+ユーザーへの事前告知・変更履歴の明示はなく、「サイレントな仕様変更」として批判された。
+
+## 対処方法
+
+`/effort max` コマンドを使うことで、以前の思考深度に近い動作を再現できる。
+
+```bash
+# Claude Code セッション内で実行
+/effort max
+```
+
+## 論点
+
+- Anthropic は思考量削減で **API コスト削減とレスポンス高速化** を実現した可能性
+- 一方、複雑なタスクでの **品質低下** を招くトレードオフ
+- ユーザーへの透明性の欠如が最大の問題として指摘された
+
+## 関連ページ
+
+- [Claude の EQ（脳内トレース能力）](/blogs/wiki/concepts/claude-eq/)
+- [Claude Mythos](/blogs/wiki/concepts/claude-mythos/)
+
+## ソース記事
+
+- [Claude の思考深度が67%低下？AMD AIディレクターの分析が示す「サイレント・ダウングレード」問題](/blogs/posts/2026/04/claude-thinking-nerfed/) — 2026-04-13

--- a/content/wiki/concepts/multi-agent-coordination-patterns.md
+++ b/content/wiki/concepts/multi-agent-coordination-patterns.md
@@ -1,0 +1,76 @@
+---
+title: "マルチエージェント調整パターン"
+description: "複数 AI エージェントを協調させる5つの設計パターン。Anthropic が体系化した Generator-Verifier・Orchestrator-Subagent・Agent Teams・Message Bus・Shared State"
+date: 2026-04-11
+lastmod: 2026-04-11
+aliases: ["マルチエージェントパターン", "multi-agent-coordination"]
+related_posts:
+  - "/posts/2026/04/anthropic-multi-agent-coordination-patterns/"
+  - "/posts/2026/04/claude-managed-agents-architecture/"
+  - "/posts/2026/04/claude-managed-agents/"
+tags: ["マルチエージェント", "AIアーキテクチャ", "設計パターン", "Anthropic", "エージェント"]
+---
+
+## 概要
+
+Anthropic が 2026年4月に公開した、複数 AI エージェントを協調させるための5つの設計パターン。「まず Orchestrator-Subagent から始め、観察した制約に応じて発展させる」という設計哲学が基本。
+
+## 5 つのパターン
+
+### 1. Generator-Verifier（生成・検証）
+
+一方のエージェントが出力を生成し、もう一方が明示的な基準で検証。不合格なら生成エージェントにフィードバックが戻り、合格か最大反復回数に達するまでループ。
+
+- **向いているケース**: コード生成＋テスト実行など、品質基準が明確なタスク
+- **注意点**: 検証基準の設計が甘いと「品質管理の幻想」になる
+
+### 2. Orchestrator-Subagent（オーケストレーター・サブエージェント）
+
+リーダーエージェントが計画を立て、専門化されたサブエージェントにタスクを委任。Anthropic 推奨の**デフォルト出発点**。
+
+- **向いているケース**: セキュリティ・テストカバレッジ・スタイルを分担するコードレビュー等
+- **注意点**: サブエージェント間の依存が高いと情報ボトルネックになる
+
+### 3. Agent Teams（エージェントチーム）
+
+コーディネーターが**永続的な**ワーカーエージェントを生成。ワーカーはアサインをまたいで生存し、ドメイン知識を蓄積する点が Orchestrator-Subagent との違い。
+
+- **向いているケース**: 大規模コードベースの長期・並列マイグレーション
+- **注意点**: タスク間の独立性が必要。完了検知が難しい
+
+### 4. Message Bus（メッセージバス）
+
+エージェントが共有ルーター経由でパブリッシュ・サブスクライブ。実行順序があらかじめ決まらないイベント駆動型。
+
+- **向いているケース**: セキュリティアラートが動的に多段階調査をトリガーするようなパイプライン
+- **注意点**: イベント連鎖のトレーサビリティが低下しやすい
+
+### 5. Shared State（共有ステート）
+
+中央コーディネーターなしに、エージェントが永続ストレージを直接読み書き。他エージェントの発見をリアルタイムに参照できる。
+
+- **向いているケース**: 一方の調査が即座に他方の探索方向に影響する協調リサーチ
+- **注意点**: 収束条件が必須。なければ際限なくトークンを消費する
+
+## 選択の目安
+
+| パターン | 向いているケース |
+|---|---|
+| Orchestrator-Subagent | 多くのユースケースの出発点 |
+| Generator-Verifier | 品質基準が明確で反復検証が必要 |
+| Agent Teams | 並列・長期・ドメイン蓄積が必要 |
+| Message Bus | イベント駆動で動的にワークフローが変化 |
+| Shared State | エージェント間でリアルタイムに知識を共有したい |
+
+実際のプロダクションでは複数パターンを組み合わせることも多い。
+
+## 関連ページ
+
+- [Claude Managed Agents](/blogs/wiki/tools/claude-managed-agents/)
+- [エージェントメモリのロックイン](/blogs/wiki/concepts/agent-memory-lock-in/)
+- [ハーネスエンジニアリング](/blogs/wiki/concepts/harness-engineering/)
+
+## ソース記事
+
+- [Anthropic が解説するマルチエージェント調整パターン 5 選](/blogs/posts/2026/04/anthropic-multi-agent-coordination-patterns/) — 2026-04-11
+- [Claude Managed Agents のアーキテクチャ: Brain / Session / Hands の分離設計](/blogs/posts/2026/04/claude-managed-agents-architecture/) — 2026-04-10


### PR DESCRIPTION
## 概要

Shopify が公開した「Shopify AI Toolkit」に関する記事。Claude Code や Cursor などの AI エージェントから MCP 経由で Shopify ストアを直接操作できる仕組みを紹介する。

**ソース**: https://github.com/hdknr/blogs/issues/1#issuecomment-4230949842

## 記事の内容

- Shopify AI Toolkit の概要と対応ツール（Claude Code, Codex, Cursor, VS Code）
- 主な機能（バックエンド直接書き込み、1プロンプトで一括操作、16スキル搭載）
- Claude Code での活用イメージ
- EC ストア構築・運用への応用可能性
