### PR TITLE
Refactor: Skills の SKILL.md を英語化 — prompt caching 効率化のため

### DIFF
--- a/.claude/skills/blog/SKILL.md
+++ b/.claude/skills/blog/SKILL.md
@@ -1,97 +1,98 @@
 ---
 name: blog
-description: Hugo ブログ記事を新規作成し、PR を作成する
+description: Create a new Hugo blog post and open a pull request
 arguments:
   - name: topic
-    description: "記事のトピック、タイトル、または GitHub Issue コメント URL"
+    description: "Post topic, title, or a GitHub issue/comment URL"
     required: true
   - name: date
-    description: "記事の日付（YYYY-MM-DD 形式）。省略時は本日"
+    description: "Post date (YYYY-MM-DD). Defaults to today."
     required: false
 ---
 
-指定されたトピックで Hugo ブログ記事を作成し、PR を作成してください。
+Create a Hugo blog post from the given topic and open a PR.
 
-## URL 制限（セキュリティ）
+## URL allowlist (security)
 
-**重要: トピックとして GitHub URL が指定された場合、`https://github.com/hdknr/blogs/` 配下の URL のみ受け付ける。**
+**Important: when the topic is a GitHub URL, only URLs under `https://github.com/hdknr/blogs/` are accepted.**
 
-- 許可: `https://github.com/hdknr/blogs/issues/...`, `https://github.com/hdknr/blogs/pull/...` など
-- 拒否: 上記以外のすべての GitHub URL（他のリポジトリ、他のオーナー）
-- 拒否された場合はエラーメッセージを表示して処理を中断する:
+- Allowed: `https://github.com/hdknr/blogs/issues/...`, `https://github.com/hdknr/blogs/pull/...`, etc.
+- Rejected: any other GitHub URL (different repo, different owner)
+- On rejection, abort and show this error message **in Japanese**:
   「エラー: このスキルで受け付ける URL は https://github.com/hdknr/blogs/ 配下のみです。」
 
-## 手順
+## Procedure
 
-### 1. トピックの種類を判定する
+### 1. Classify the topic
 
-トピック引数が以下のいずれかを判定する:
+Decide which of the following the argument is:
 
-- **GitHub Issue コメント URL**: `https://github.com/hdknr/blogs/issues/{number}#issuecomment-{id}` 形式
-- **GitHub Issue URL**: `https://github.com/hdknr/blogs/issues/{number}` 形式
-- **テキストトピック**: 上記以外のテキスト（URL でないもの）
-- **許可されていない URL**: 上記以外の URL → エラーで中断
+- **GitHub issue-comment URL**: `https://github.com/hdknr/blogs/issues/{number}#issuecomment-{id}`
+- **GitHub issue URL**: `https://github.com/hdknr/blogs/issues/{number}`
+- **Text topic**: anything that is not a URL
+- **Disallowed URL**: anything else → abort with the error above
 
-### 2. GitHub Issue コメント URL の場合
+### 2. GitHub issue-comment URL
 
-URL からコメント内容を取得してブログ記事のソースにする:
+Fetch the comment body and use it as the post source:
 
-1. URL をパースして `owner`, `repo`, `issue_number`, `comment_id` を抽出する
-2. コメント本文を取得する:
+1. Parse the URL into `owner`, `repo`, `issue_number`, `comment_id`.
+2. Fetch the comment:
    ```bash
    gh api /repos/{owner}/{repo}/issues/comments/{comment_id} --jq '{body, created_at, html_url}'
    ```
-3. Issue のタイトルも取得する:
+3. Fetch the issue title too:
    ```bash
    gh api /repos/{owner}/{repo}/issues/{issue_number} --jq '{title, body}'
    ```
-4. コメント本文をブログ記事の内容として使用する
-5. 記事タイトルはコメント内容の最初の見出し（`#` or `##`）から取得する。見出しがなければ Issue タイトルを使用する
-6. 日付はコメントの `created_at` から取得する（引数で上書き可能）
-7. フロントマターに `source_url` としてコメントの `html_url` を記録する
+4. Use the comment body as the post content.
+5. Take the post title from the first heading (`#` or `##`) in the comment body. If absent, fall back to the issue title.
+6. Take the date from the comment's `created_at` (overridable by the `date` argument).
+7. Record the comment's `html_url` in the frontmatter as `source_url`.
 
-### 3. GitHub Issue URL の場合
+### 3. GitHub issue URL
 
-Issue 本文を取得してブログ記事のソースにする:
+Fetch the issue body and use it as the post source:
 
-1. URL をパースして `owner`, `repo`, `issue_number` を抽出する
-2. Issue の情報を取得する:
+1. Parse the URL into `owner`, `repo`, `issue_number`.
+2. Fetch the issue:
    ```bash
    gh api /repos/{owner}/{repo}/issues/{issue_number} --jq '{title, body, created_at, html_url}'
    ```
-3. Issue 本文をブログ記事の内容として使用する
-4. 記事タイトルは Issue タイトルを使用する
-5. フロントマターに `source_url` として Issue の `html_url` を記録する
+3. Use the issue body as the post content.
+4. Use the issue title as the post title.
+5. Record the issue's `html_url` in the frontmatter as `source_url`.
 
-### 4. テキストトピックの場合
+### 4. Text topic
 
-- トピックに基づいて、技術ブログ記事としてふさわしい内容を作成する
-- ユーザーがトピックのみ指定した場合は、WebSearch で最新情報を調査して記事を作成する
-- ユーザーが内容も指定した場合は、その内容をベースに記事を整形する
+- Compose a technical blog post that fits the topic.
+- If the user only provided a topic, use WebSearch to research the latest information first.
+- If the user also supplied content, use that as the base and reshape it into a post.
 
-### 5. 対象日付を決定する
+### 5. Decide the target date
 
-- 引数で日付（YYYY-MM-DD）が指定されている場合はその日付を使用する
-- GitHub URL の場合はコメント/Issue の `created_at` を使用する
-- それ以外の場合は今日の日付を使用する（`date +%Y-%m-%d`）
+- If the `date` argument is given (YYYY-MM-DD), use it.
+- For a GitHub URL, use the comment/issue `created_at`.
+- Otherwise, use today (`date +%Y-%m-%d`).
 
-### 6. 記事ファイルを作成する
+### 6. Create the post file
 
-- ファイルパス: `content/posts/YYYY/MM/YYYY-MM-DD-<slug>.md`
-- `<slug>` はトピックから生成する（英数字・ハイフンのみ、小文字）
-- 同名ファイルが既に存在する場合はサフィックスを追加する（例: `-2`）
+- Path: `content/posts/YYYY/MM/YYYY-MM-DD-<slug>.md`
+- `<slug>`: derived from the topic (lowercase, alphanumerics and hyphens only)
+- If the file already exists, add a suffix (e.g. `-2`).
 
-### 7. カテゴリとタグを自動付与する
+### 7. Auto-assign categories and tags
 
-- `scripts/categorize.py` のルールに基づいて、記事の内容からカテゴリとタグを判定する
-- カテゴリは以下から最適なものを1つ選択する:
+- Follow the rules in `scripts/categorize.py` to derive the category and tags from the post body.
+- Pick exactly **one** category from:
   - AI/LLM, セキュリティ, クラウド/インフラ, Web開発, プログラミング言語,
     モバイル, データベース, ツール/開発環境, ビジネス/キャリア, 地域/グルメ, その他
-- タグは内容に関連するものを最大5つ選択する
+  - (Category names stay in Japanese — they are literal frontmatter values consumed by `scripts/categorize.py`.)
+- Pick up to 5 tags relevant to the content.
 
-## フロントマターのテンプレート
+## Frontmatter templates
 
-GitHub URL ソースの場合:
+GitHub-URL-sourced post:
 
 ```yaml
 ---
@@ -105,7 +106,7 @@ tags: ["tag1", "tag2"]
 ---
 ```
 
-テキストトピックの場合:
+Text-topic post:
 
 ```yaml
 ---
@@ -118,219 +119,221 @@ tags: ["tag1", "tag2"]
 ---
 ```
 
-## 外部 URL のフェッチ方針
+> The title field is written in Japanese — the post body is Japanese, and so is the user-facing title.
 
-記事作成・ファクトチェックを問わず、外部 URL のコンテンツを取得する際は以下の優先順位に従う:
+## External URL fetching
 
-1. **`aegis_fetch` を優先使用する**
-   - セキュリティスキャン（verdict: allow/warn/block）付きでコンテンツを取得できる
-   - verdict が "warn" → ユーザーに警告を表示して確認を求める
-   - verdict が "block" → コンテンツを使用せず、ユーザーに報告する
-   - 取得した HTML/JSON の解析は Claude が直接行う
+When fetching external URLs (for either drafting or fact-checking), follow this priority order:
 
-2. **`aegis_fetch` が利用できない場合は `WebFetch` にフォールバック**
-   - MCP 未接続、aegis 未起動などの場合
+1. **Prefer `aegis_fetch`**
+   - Returns content together with a security verdict (`allow`/`warn`/`block`).
+   - verdict `warn` → show the warning to the user and ask for confirmation.
+   - verdict `block` → do not use the content; report to the user.
+   - Claude parses the returned HTML/JSON directly.
 
-3. **`aegis_fetch` の大きな結果の扱い**
-   - 結果がトークン上限を超えると、Claude Code が自動的に `~/.claude/projects/.../tool-results/` に保存する
-   - このパスは保護対象（sensitive file）のため、`cp` や `Grep` でアクセスすると同意確認が発生する
-   - **対処: `.claude/temp/` にコピーしてから Read/Grep する**
+2. **Fall back to `WebFetch` if `aegis_fetch` is unavailable**
+   - MCP not connected, aegis not running, etc.
+
+3. **Handling large `aegis_fetch` results**
+   - If the result exceeds the token limit, Claude Code auto-saves it under `~/.claude/projects/.../tool-results/`.
+   - That path is treated as a sensitive file, so `cp` or `Grep` against it triggers a consent prompt.
+   - **Workaround: copy it into `.claude/temp/` first, then Read/Grep there.**
      ```bash
      cp /Users/hdknr/.claude/projects/.../tool-results/mcp-aegis-aegis_fetch-XXXX.txt .claude/temp/aegis-result.txt
      ```
-   - 作業完了後は `.claude/temp/` 内のコピーを削除する
-   - **同意プロンプトの恒久対策**: 初回の同意プロンプトで「Yes, and always allow access to tool-results/ from this project」を選択すれば、以降の `tool-results/` へのアクセスは自動許可される
+   - Delete the copy from `.claude/temp/` when done.
+   - **Permanent fix for the consent prompt**: on the first prompt, choose "Yes, and always allow access to tool-results/ from this project". After that, accesses to `tool-results/` are auto-approved.
 
-4. **SPA（JavaScript 描画）サイトの場合**
-   - `aegis_fetch` / `WebFetch` どちらでも生 HTML からコンテンツを取得できない場合がある
-   - X (Twitter) の場合: URL を `api.fxtwitter.com` に変換して JSON API 経由で取得する
-   - その他の SPA: `WebSearch` で該当ページの情報を検索する
+4. **SPA (JavaScript-rendered) sites**
+   - Sometimes neither `aegis_fetch` nor `WebFetch` can extract content from the raw HTML.
+   - X (Twitter): rewrite the URL to `api.fxtwitter.com` and fetch via its JSON API.
+   - Other SPAs: use `WebSearch` to retrieve information about the page.
 
-## 記事の構成ガイドライン
+## Post-structure guidelines
 
-- 見出し（##）を使って構造化する
-- コード例がある場合はシンタックスハイライト付きのコードブロックを使用する
-- 日本語で記述する
-- 冒頭に概要・導入を書く
-- 実用的な情報を含める（コマンド例、設定例、コードサンプルなど）
-- GitHub コメント/Issue からの内容はそのまま活かしつつ、ブログ記事として読みやすく整形する
+- Structure the post with `##` headings.
+- Use syntax-highlighted code blocks for code examples.
+- **Write the post body in Japanese.**
+- Open with an overview / introduction.
+- Include practical material (commands, configuration snippets, code samples).
+- When the source is a GitHub comment/issue, preserve its content but reshape it into readable blog prose.
 
-### ダイアグラム（図）の作成ルール
+### Diagram rules
 
-アーキテクチャ図やフロー図が必要な場合、**アスキーアートは使わず drawio で画像化する**。
+When an architecture or flow diagram is needed, **do not use ASCII art** — render it with drawio.
 
-1. drawio ファイルを作成する: `static/images/<slug>-<diagram-name>.drawio`
-2. PNG にエクスポートする（`--scale 2` で高解像度）:
+1. Create a drawio source file: `static/images/<slug>-<diagram-name>.drawio`
+2. Export to PNG (`--scale 2` for high resolution):
    ```bash
    /Applications/draw.io.app/Contents/MacOS/draw.io --export --format png --scale 2 --output static/images/<name>.png static/images/<name>.drawio
    ```
-3. 記事内で絶対パスで参照する:
+3. Reference it from the post using an absolute path:
    ```markdown
    ![図の内容を自然文で記述した alt テキスト](/blogs/images/<name>.png)
    ```
-4. **alt テキスト**: 図の内容を自然文で記述する（SEO の画像検索露出 + アクセシビリティ向上）
-5. **相対パス（`../../images/`）は使わない**: Hugo のパーマリンク構造で 404 になるため、必ず `/blogs/images/` の絶対パスを使う
-6. 既存の drawio ファイル（`static/images/openclaw-gateway-architecture.drawio` 等）のスタイルを参考にする
+4. **alt text**: describe the diagram in natural Japanese prose (improves image-search SEO + accessibility).
+5. **Do not use relative paths (`../../images/`)** — Hugo's permalink layout turns them into 404s. Always use the absolute `/blogs/images/` form.
+6. Match the visual style of existing drawio files (e.g. `static/images/openclaw-gateway-architecture.drawio`).
 
-## ファクトチェック（情報検証）
+## Fact-checking
 
-記事をコミットする前に、以下の手順で記事内の事実関係を検証する。
-**このステップは省略してはならない。**
+Before committing the post, verify the facts it contains.
+**This step is mandatory.**
 
-### 検証対象
+### What to verify
 
-記事内の以下の項目をすべて抽出して検証する:
+Extract and verify every item in the following categories:
 
-1. **ツール・サービス・ライブラリの存在確認**
-   - 記事で言及しているツール、プラグイン、ライブラリ、サービスが実在するか
-   - GitHub リポジトリの URL が記載されている場合、`gh api` で存在を確認する:
+1. **Existence of tools / services / libraries**
+   - Verify that any tool, plugin, library, or service mentioned actually exists.
+   - For GitHub repo URLs, confirm with `gh api`:
      ```bash
      gh api /repos/{owner}/{repo} --jq '.full_name' 2>&1
      ```
-   - 公式サイトの URL がある場合、「外部 URL のフェッチ方針」に従って取得・検証する
+   - For official-site URLs, fetch and verify according to "External URL fetching".
 
-2. **コマンド・APIの正確性**
-   - 記事に記載されているインストールコマンドや CLI コマンドが正しい構文か
-   - WebSearch で公式ドキュメントを検索し、コマンド構文を照合する
+2. **Command / API correctness**
+   - Confirm that install commands and CLI commands in the post use the correct syntax.
+   - Cross-check against official documentation via WebSearch.
 
-3. **機能・仕様の正確性**
-   - 記事で説明している機能や仕様が実際に存在するか
-   - WebSearch で公式ドキュメントやリリースノートを確認する
+3. **Feature / spec correctness**
+   - Confirm that the features and specs described actually exist.
+   - Check official docs and release notes via WebSearch.
 
-4. **バージョン・日付の正確性**
-   - 記載されているバージョン番号やリリース日が正しいか
+4. **Version / date accuracy**
+   - Confirm version numbers and release dates are correct.
 
-### 検証手順
+### Verification procedure
 
-1. 記事から検証すべき事実（claims）をリストアップする
-2. 各事実について WebSearch または `gh api` で裏付けを取る
-3. 検証結果を以下の形式で整理する:
-   - ✅ **確認済み**: 裏付けが取れた事実
-   - ⚠️ **要修正**: 部分的に正しいが修正が必要な事実
-   - ❌ **誤り**: 裏付けが取れなかった事実（ハルシネーションの可能性）
-   - ℹ️ **未確認**: 検証できなかったが重大なリスクは低い事実
-4. ⚠️ または ❌ の項目がある場合は、記事を修正してから次のステップに進む
-5. 検証結果をユーザーに報告し、修正内容の確認を求める
+1. List every claim that needs verification.
+2. Back each one up via WebSearch or `gh api`.
+3. Tag the results:
+   - ✅ **Confirmed** — verified
+   - ⚠️ **Needs fix** — partially correct, needs adjustment
+   - ❌ **Wrong** — could not be verified (possible hallucination)
+   - ℹ️ **Unverified** — could not verify but low risk
+4. If any ⚠️ or ❌ remains, fix the post before moving on.
+5. Report the verification result to the user and ask for confirmation.
 
-### 検証の重点ポイント
+### Verification focus areas
 
-- **GitHub リポジトリの存在**: 記事内の GitHub URL は必ず `gh api` で確認する
-- **コマンド構文**: インストールコマンドや設定コマンドは公式ドキュメントと照合する
-- **プラグイン・拡張機能**: 「公式」と謳っている場合、本当に公式かを確認する
-- **ソースがない独自の主張**: ソース元にない情報を記事作成時に追加した場合、特に慎重に検証する
+- **GitHub repo existence**: every GitHub URL in the post must be checked via `gh api`.
+- **Command syntax**: cross-check install/configuration commands against official docs.
+- **"Official" plugins/extensions**: when the post claims something is "official", verify it.
+- **Original claims without a source**: be especially strict on any claim added during drafting that is not in the source material.
 
-## エージェントレビュー（品質向上）
+## Agent review (quality)
 
-ファクトチェック完了後、コミット前に以下の 2 つのカスタムエージェントを **並列実行** して記事の品質を高める。
-**このステップは省略してはならない。**
+After fact-checking and before committing, **run two custom agents in parallel** to raise post quality.
+**This step is mandatory.**
 
-### 実行方法
+### How to run
 
-Agent ツールで `tech-writer` と `seo-advisor` を同時に起動する:
+Trigger `tech-writer` and `seo-advisor` simultaneously via the Agent tool:
 
 ```
 Agent(subagent_type="tech-writer", prompt="以下の記事をレビューしてください: $WORKTREE_DIR/content/posts/YYYY/MM/YYYY-MM-DD-<slug>.md")
 Agent(subagent_type="seo-advisor", prompt="以下の記事を分析してください: $WORKTREE_DIR/content/posts/YYYY/MM/YYYY-MM-DD-<slug>.md")
 ```
 
-- 2 つのエージェントは独立しているため、必ず **1 つのメッセージで並列起動** する
-- エージェントは記事を読み取ってレビュー結果を返すだけで、ファイルは編集しない
+- The two agents are independent, so launch them **in a single message** in parallel.
+- The agents only read the post and return review notes; they do not edit files.
 
-### レビュー結果の反映
+### Acting on review results
 
-1. 両エージェントの結果を受け取る
-2. 改善提案を以下の基準でフィルタリングする:
-   - **即座に反映**: 誤字脱字、表記揺れ、明らかな構成の問題、タグの過不足
-   - **ユーザーに確認**: タイトルの変更提案、カテゴリの変更提案、大幅な構成変更
-   - **スキップ**: 好みの問題（文体の微調整など）、既存記事への内部リンク追加（別 PR で対応）
-3. 反映した改善内容をユーザーに簡潔に報告する
+1. Collect both agents' outputs.
+2. Filter the suggestions by priority:
+   - **Apply immediately**: typos, inconsistent spelling, obvious structural issues, missing/extraneous tags
+   - **Ask the user**: title changes, category changes, large structural rewrites
+   - **Skip**: stylistic taste calls (minor wording), adding internal links to existing posts (handle in a separate PR)
+3. Report the applied changes concisely to the user.
 
-## コミット・ブランチ・PR 作成（worktree 方式）
+## Commit / branch / PR creation (worktree pattern)
 
-記事作成後、以下の手順で PR を作成する。
-**重要: git worktree を使い、メインの作業ディレクトリのブランチを汚さないようにする。**
-**重要: コマンドを `&&` で繋がないこと。** `&&` で繋いだ複合コマンドは許可パターンにマッチせず、毎回確認が求められる。各コマンドは個別の Bash 呼び出しとして実行する。
+After drafting the post, open a PR following this procedure.
+**Important: use a git worktree so the main working tree stays clean.**
+**Important: do not chain commands with `&&`.** Chained commands break the allowlist patterns and trigger a confirmation prompt every time. Issue each command as a separate Bash call.
 
-1. ブランチ名を決定する: `blog/YYYY-MM-DD-<slug>`
-2. worktree を作成する:
+1. Decide the branch name: `blog/YYYY-MM-DD-<slug>`
+2. Create the worktree:
    ```bash
-   # メインリポジトリのルートで実行（main ブランチのまま）
+   # Run from the main repo root (stay on main)
    BRANCH_NAME="blog/YYYY-MM-DD-<slug>"
    git worktree add -b "$BRANCH_NAME" ".worktrees/<slug>" main
    ```
-3. **worktree の絶対パスを取得する（重要）:**
+3. **Get the absolute path of the worktree (important):**
    ```bash
    git worktree list
    ```
-   出力から worktree の絶対パスを読み取り、以降はその絶対パスを `$WORKTREE_DIR` として使う。
-   **相対パスから絶対パスを推測してはならない。** Write ツールは存在しないパスにもファイルを作成するため、パスを間違えてもエラーにならず手戻りが発生する。
-4. worktree 内で記事ファイルを作成する:
-   - 記事の書き込み先: `$WORKTREE_DIR/content/posts/YYYY/MM/YYYY-MM-DD-<slug>.md`
-5. worktree 内で Hugo ビルド確認（`cd` を使わず `--source` で指定）:
+   Read the absolute path from the output and use it as `$WORKTREE_DIR` for everything that follows.
+   **Do not guess the absolute path from a relative one.** The Write tool happily creates files at non-existent paths, so a wrong path will silently fail with no error and force a redo.
+4. Create the post file inside the worktree:
+   - Path: `$WORKTREE_DIR/content/posts/YYYY/MM/YYYY-MM-DD-<slug>.md`
+5. Check the Hugo build inside the worktree (use `--source` instead of `cd`):
    ```bash
    hugo --source "$WORKTREE_DIR" --gc 2>&1 | tail -5
    ```
-6. worktree 内でコミット・プッシュ（`cd` を使わず `git -C` で指定）:
+6. Commit and push inside the worktree (use `git -C` instead of `cd`):
    ```bash
    git -C "$WORKTREE_DIR" add content/posts/YYYY/MM/YYYY-MM-DD-<slug>.md
-   git -C "$WORKTREE_DIR" commit -m "Add blog post: <記事タイトル>"
+   git -C "$WORKTREE_DIR" commit -m "Add blog post: <post-title-in-Japanese>"
    git -C "$WORKTREE_DIR" push -u origin "$BRANCH_NAME"
    ```
-7. PR を作成する（`--head` でブランチを明示指定し、`cd` を使わない）:
-   PR 本文は worktree 内に書き出し、`--body-file` で渡す。worktree は `.claude/` の外にあるため、Write ツールで直接書き込める。
+7. Create the PR (explicitly pin the branch with `--head` and avoid `cd`):
+   Write the PR body to a file inside the worktree, then pass it via `--body-file`. The worktree is outside `.claude/`, so the Write tool can write to it directly.
    ```bash
-   # Write ツールで $WORKTREE_DIR/pr_body.md に PR 本文を書き出す
-   gh pr create --repo hdknr/blogs --head "$BRANCH_NAME" --title "Add blog: <記事タイトル>" --body-file "$WORKTREE_DIR/pr_body.md"
+   # Use the Write tool to write the PR body to $WORKTREE_DIR/pr_body.md
+   gh pr create --repo hdknr/blogs --head "$BRANCH_NAME" --title "Add blog: <post-title-in-Japanese>" --body-file "$WORKTREE_DIR/pr_body.md"
    ```
-   **注意: `cd "$WORKTREE_DIR" && gh pr create` は使わないこと。** `cd` で始まるコマンドは `Bash(gh:*)` の許可パターンにマッチせず、毎回確認が求められる。`--head` フラグでブランチを指定すれば worktree 内にいる必要はない。
-   **注意: `--body "$(cat <<'EOF'...)"` 方式は使わないこと。** HEREDOC 内の `#` 付き行がセキュリティチェック（"quoted newline followed by #-prefixed line"）に引っかかり、毎回確認が求められる。
-8. PR の URL を控える（ソース元への追記に使用する）
-9. **PR がマージされたら worktree を削除する。** ユーザーがマージを指示・確認した直後に `git worktree remove --force "$WORKTREE_DIR"` を実行する（`pr_body.md` 等の未追跡ファイルが残るため `--force` が必要）。
+   **Note: do not use `cd "$WORKTREE_DIR" && gh pr create`.** Commands that start with `cd` do not match the `Bash(gh:*)` allowlist pattern and trigger a prompt every time. As long as you pass `--head`, you do not need to be inside the worktree.
+   **Note: do not use the `--body "$(cat <<'EOF'...)"` style.** Lines starting with `#` inside the HEREDOC trip a security check ("quoted newline followed by #-prefixed line") and trigger a prompt every time.
+8. Note the PR URL (used when linking back to the source).
+9. **Remove the worktree once the PR is merged.** When the user confirms the merge, run `git worktree remove --force "$WORKTREE_DIR"` (the `--force` is needed because of untracked files like `pr_body.md`).
 
-## ソース元への PR リンク追記とブログ化マーク
+## Link back to source + 🚀-reaction mark
 
-PR 作成後、トピックが GitHub URL だった場合はソース元にブログ PR のリンクを追記し、🚀 リアクションでブログ化済みをマークする。
+After the PR is created, if the topic came from a GitHub URL, post the PR link back to the source and mark it as blogged with a 🚀 reaction.
 
-### Issue コメント URL がソースの場合
+### Source is an issue-comment URL
 
-元のコメントを更新して、末尾にブログ PR リンクを追記する。
-**スクリプト `.claude/scripts/update-issue-comment.sh` を使用すること。**
+Edit the source comment and append the blog PR link at the end.
+**Use the helper script `.claude/scripts/update-issue-comment.sh`.**
 
-PR URL を一時ファイルに書き出してからスクリプトに渡す（URL を直接引数に含めるとセキュリティチェックが発動するため）。
-**書き出し先は worktree 内（`$WORKTREE_DIR/pr-url.txt`）にすること。** `.claude/temp/` に書くと既存ファイルの上書き確認が発生する場合がある。worktree 内なら `Write(//.worktrees/**)` の許可パターンにマッチし、worktree 削除時にまとめてクリーンアップされる。
+Write the PR URL to a temp file first, then pass that file to the script (passing the URL as a literal argument trips a security check).
+**Place the temp file inside the worktree (`$WORKTREE_DIR/pr-url.txt`).** Putting it under `.claude/temp/` may cause an overwrite-confirmation prompt; placing it inside the worktree matches the `Write(//.worktrees/**)` allowlist and gets cleaned up automatically when the worktree is removed.
 
 ```bash
-# 1. Write ツールで $WORKTREE_DIR/pr-url.txt に PR URL を書き出す
-# 2. スクリプトにファイルパスを渡す
+# 1. Use the Write tool to write the PR URL to $WORKTREE_DIR/pr-url.txt
+# 2. Pass the file path to the script
 bash .claude/scripts/update-issue-comment.sh {owner} {repo} {comment_id} $WORKTREE_DIR/pr-url.txt
 ```
 
-例:
+Example:
 ```bash
-# Write ツールで $WORKTREE_DIR/pr-url.txt に "https://github.com/hdknr/blogs/pull/141" を書き出す
+# Use Write to put "https://github.com/hdknr/blogs/pull/141" into $WORKTREE_DIR/pr-url.txt
 bash .claude/scripts/update-issue-comment.sh hdknr blogs 4126127772 $WORKTREE_DIR/pr-url.txt
 ```
 
-このスクリプトは以下を自動実行する:
-1. `gh api` でコメント本文を取得
-2. PR リンクを末尾に追記
-3. `jq` で JSON を構築
-4. `gh api --method PATCH` でコメントを更新
-5. 一時ファイルをクリーンアップ
+The script:
+1. fetches the comment body via `gh api`
+2. appends the PR link
+3. builds the JSON with `jq`
+4. updates the comment via `gh api --method PATCH`
+5. cleans up the temp file
 
-### 🚀 リアクションでブログ化済みをマーク
+### Mark as blogged with 🚀
 
-PR リンク追記後、ソースコメントに 🚀 リアクションを付けてブログ化済みをマークする:
+After appending the PR link, add a 🚀 reaction on the source comment to mark it as blogged:
 
 ```bash
 gh api repos/{owner}/{repo}/issues/comments/{comment_id}/reactions -f content=rocket
 ```
 
-**重要:** 重複トピック等でブログ化を見送った場合も、手動で 🚀 を付けて「対応済み」を示す。
+**Important:** when a comment is intentionally skipped (e.g. duplicate topic), still add 🚀 manually to mark it as "handled".
 
-### Issue URL がソースの場合
+### Source is an issue URL
 
-Issue に新しいコメントを追加して PR リンクを通知する:
+Add a new comment on the issue announcing the PR link:
 
 ```bash
 gh api /repos/{owner}/{repo}/issues/{issue_number}/comments \
@@ -338,24 +341,26 @@ gh api /repos/{owner}/{repo}/issues/{issue_number}/comments \
   --field body="📝 この Issue からブログ記事を作成しました: <PR_URL>"
 ```
 
-## 後処理
+> The announcement comment body is written in Japanese — it is user-facing.
 
-1. 作成した PR の URL をユーザーに伝える
-2. PR マージ後、worktree を自動削除する（`pr_body.md` 等の未追跡ファイルが残るため `--force` が必要）:
+## Post-merge follow-up
+
+1. Send the PR URL to the user.
+2. After merge, auto-remove the worktree (force-remove because of untracked files like `pr_body.md`):
    ```bash
    git worktree remove --force "$WORKTREE_DIR"
    ```
-3. **Wiki 自動 Ingest チェック**: PR マージ後、以下の手順で Wiki 更新の要否を判定する:
-   1. `.claude/wiki-last-ingest.txt` から最終 ingest 日付を読み取る（ファイルがなければ `1970-01-01`）
-   2. `content/posts/` 内で最終 ingest 日付以降に作成された記事数をカウントする（フロントマターの `date` を参照）
-   3. **20件以上** の場合: `/wiki-ingest all` を自動実行し、完了後に `.claude/wiki-last-ingest.txt` を今日の日付で更新する
-   4. **20件未満** の場合: 「Wiki 更新まであと N 件」とだけ報告する（ingest は実行しない）
+3. **Wiki auto-ingest check**: after merge, decide whether to run `/wiki-ingest`:
+   1. Read the last ingest date from `.claude/wiki-last-ingest.txt` (default `1970-01-01` if missing).
+   2. Count posts in `content/posts/` whose frontmatter `date` is on or after that date.
+   3. **≥ 20 posts**: auto-run `/wiki-ingest all`, then update `.claude/wiki-last-ingest.txt` to today.
+   4. **< 20 posts**: just report "Wiki update in N more posts" (do not run ingest).
 
    ```bash
-   # 最終 ingest 日付の読み取り例
+   # Read the last ingest date
    cat .claude/wiki-last-ingest.txt
    # → 2026-04-06
 
-   # ingest 完了後の更新例（Write ツールで書き込む）
-   # .claude/wiki-last-ingest.txt に今日の日付を書き込む
+   # After running ingest, use the Write tool to set
+   # .claude/wiki-last-ingest.txt to today's date.
    ```

--- a/.claude/skills/permission-review/SKILL.md
+++ b/.claude/skills/permission-review/SKILL.md
@@ -1,118 +1,118 @@
 ---
 name: permission-review
-description: セッション中に同意を求められたコマンドのログを分析し、許可設定やワークフローの改善提案を行う
+description: Analyse commands that triggered consent prompts during the session and propose changes to allowlist rules or workflow
 arguments:
   - name: log_file
-    description: "同意ログファイルのパス（省略時はセッションの会話コンテキストから分析）"
+    description: "Path to a consent-log file. If omitted, analyse the current session's conversation context."
     required: false
 ---
 
-セッション中に同意（permission prompt）を求められたコマンドのログを分析し、次回以降の同意を減らすための改善提案を行ってください。
+Analyse the commands that triggered permission prompts during the session and propose changes that reduce future prompts.
 
-## 入力
+## Input
 
-### 入力ソースの優先順位
+### Input-source priority
 
-1. **引数 `log_file` が指定された場合**: そのファイルを読み取る
-2. **引数なしの場合（デフォルト）**: 現在のセッションの会話コンテキストから同意プロンプトを分析する
+1. **`log_file` argument given**: read that file.
+2. **No argument (default)**: analyse the consent prompts in the current session's conversation context.
 
-### ファイルからの入力
+### File-based input
 
-ログファイルには以下のような形式で同意プロンプトが記録されている想定:
+A consent-log file is expected to contain entries shaped roughly like:
 
 ```
 Bash command
-  <コマンド内容>
-  <説明>
+  <command body>
+  <description>
 
 Do you want to proceed?
 ```
 
-形式が多少異なっていても、「Bash command」「Do you want to proceed?」等のキーワードから同意プロンプトを抽出すること。
+Even if the exact format differs, extract consent prompts based on signals such as `Bash command` and `Do you want to proceed?`.
 
-### 会話コンテキストからの入力（デフォルト）
+### Conversation-context input (default)
 
-ファイルが指定されていない場合は、現在の会話の中でユーザーが同意を求められた場面を分析する。以下の手がかりから同意プロンプトを特定する:
+When no file is supplied, analyse the current conversation. Use these signals to spot consent prompts:
 
-- ツール呼び出しがユーザーによって拒否・承認された記録
-- `Do you want to proceed?` のようなプロンプト
-- ユーザーが許可操作について言及したメッセージ
-- セッション中に実行されたコマンドのうち、`settings.local.json` の許可パターンにマッチしないもの
+- Tool calls that the user explicitly denied or approved.
+- Prompts that look like `Do you want to proceed?`.
+- User messages mentioning permission decisions.
+- Commands executed during the session that do not match any allowlist pattern in `settings.local.json`.
 
-**同意プロンプトが見つからない場合**: 「このセッションでは同意を求められたコマンドはありませんでした」と報告して終了する。
+**If no consent prompts are found**: report "このセッションでは同意を求められたコマンドはありませんでした" and exit.
 
-## 分析手順
+## Analysis procedure
 
-### 1. 同意プロンプトの抽出
+### 1. Extract consent prompts
 
-入力ソース（ファイルまたは会話コンテキスト）から、同意を求められた各コマンドを抽出し、以下の情報を整理する:
+From the input source (file or conversation), extract every consenting command and collect:
 
-- **コマンド内容**: 実行しようとしたコマンド
-- **説明**: コマンドの説明テキスト
-- **警告メッセージ**: セキュリティチェックの警告があれば記録（例: "Command contains a quoted newline..."）
+- **Command body**: the command that was about to run.
+- **Description**: the descriptive text.
+- **Warning message**: any security-check warning (e.g. "Command contains a quoted newline...").
 
-### 2. 原因の分類
+### 2. Classify the cause
 
-各コマンドについて、同意が求められた原因を以下のカテゴリに分類する:
+Classify each command's cause into one of the following:
 
-| カテゴリ | 説明 | 例 |
+| Category | Description | Example |
 |---|---|---|
-| **パターン未登録** | 許可パターンに該当するものがない | `git worktree add` |
-| **セキュリティチェック** | コマンド内容がセキュリティルールに抵触 | HEREDOC 内の `#` 行、`$()` 置換 |
-| **パス制限** | アクセス先のパスが許可されていない | `/tmp` への書き込み |
-| **複合コマンド** | `&&` や `\|` で繋いだコマンドがパターンにマッチしない | `rm ... && git worktree remove ...` |
-| **外部通信** | 外部サービスへの書き込み操作 | `gh api --method PATCH` |
+| **Pattern missing** | No allowlist pattern matches | `git worktree add` |
+| **Security check** | Triggered a security rule | `#`-prefixed line inside a HEREDOC, `$()` substitution |
+| **Path restriction** | Target path is not allowed | write to `/tmp` |
+| **Compound command** | Command chained with `&&` / `\|` does not match a pattern | `rm ... && git worktree remove ...` |
+| **External write** | Write operation to an external service | `gh api --method PATCH` |
 
-### 3. 現在の許可設定の確認
+### 3. Inspect the current allowlist
 
-以下のファイルを読み取り、現在の許可パターンを把握する:
+Read these to understand the current permissions:
 
-- `.claude/settings.local.json` の `permissions.allow` 配列
-- CLAUDE.md のルール
-- `.claude/skills/` 配下のスキル定義
+- `permissions.allow` array in `.claude/settings.local.json`
+- Rules in `CLAUDE.md`
+- Skill definitions under `.claude/skills/`
 
-### 4. 改善提案の作成
+### 4. Build improvement proposals
 
-各コマンドについて、以下の優先順位で改善策を提案する:
+For each command, suggest improvements in this priority order:
 
-#### 優先度1: 許可パターンの追加（最もシンプル）
+#### Priority 1: Add an allowlist pattern (simplest)
 
-コマンドが安全であり、今後も繰り返し使う場合は `settings.local.json` に許可パターンを追加する。
+If the command is safe and likely to recur, add a pattern to `settings.local.json`.
 
 ```json
 "Bash(git worktree:*)"
 ```
 
-**提案時の注意:**
-- パターンは必要最小限の範囲にする（`Bash(*)` のような広すぎるパターンは提案しない）
-- 外部への書き込み操作（PATCH、POST、DELETE）は慎重に判断する
+**Cautions:**
+- Make the pattern as narrow as possible (do not propose anything as broad as `Bash(*)`).
+- Be conservative about external write operations (PATCH, POST, DELETE).
 
-#### 優先度2: ワークフローの変更（根本対策）
+#### Priority 2: Workflow change (root cause)
 
-コマンド自体を変更することで同意を回避できる場合:
+If changing the command itself avoids the prompt:
 
-- HEREDOC → `--body-file` 方式（`#` 行の問題を回避）
-- `$()` コマンド置換 → 一時ファイル + `--input` 方式
-- `/tmp` → `.claude/temp/`（プロジェクト内の一時ディレクトリ）
-- `&&` で繋いだコマンド → 個別実行
+- HEREDOC → `--body-file` (avoids the `#`-line trigger)
+- `$()` substitution → temp file + `--input`
+- `/tmp` → `.claude/temp/` (in-project scratch dir)
+- `&&` chain → split into separate calls
 
-#### 優先度3: スキル定義の更新
+#### Priority 3: Update skill definitions
 
-スキル定義（SKILL.md）のコマンド例を修正し、次回から問題のあるパターンを使わないようにする。
+Edit the relevant `SKILL.md` so future runs do not produce the problematic pattern.
 
-### 5. リスク評価
+### 5. Risk assessment
 
-各改善提案について、セキュリティリスクを評価する:
+For each proposal, assess the security risk:
 
-- **低リスク**: ローカルのみの操作（ファイル読み書き、git 操作）
-- **中リスク**: 外部サービスへの読み取り操作（gh api GET）
-- **高リスク**: 外部サービスへの書き込み操作（gh api PATCH/POST）
+- **Low**: local-only operations (file read/write, git)
+- **Medium**: external read operations (`gh api` GET)
+- **High**: external write operations (`gh api` PATCH / POST)
 
-高リスクの操作に対しては、許可パターン追加ではなくワークフロー改善を優先する。
+For high-risk operations, prefer a workflow fix over a new allowlist entry.
 
-## 出力形式
+## Output format
 
-以下の形式でレポートを出力する:
+Emit a report in this shape:
 
 ```markdown
 ## Permission Review レポート
@@ -141,13 +141,15 @@ Do you want to proceed?
 - ...
 ```
 
-## 適用
+> The report is user-facing, so the prose stays Japanese.
 
-レポートを提示した後、ユーザーの承認を得てから改善を適用する。
-適用する場合は以下のファイルを更新する:
+## Applying changes
 
-1. `.claude/settings.local.json` — 許可パターンの追加
-2. `.claude/skills/*/SKILL.md` — コマンド例の修正
-3. `CLAUDE.md` — 必要に応じてルールの追記
+After presenting the report, get user approval before applying any change.
+When applying, update the appropriate file(s):
 
-**重要: 適用前に必ずユーザーの確認を取ること。** 許可パターンの変更はセキュリティに直結するため、自動適用しない。
+1. `.claude/settings.local.json` — add allowlist patterns
+2. `.claude/skills/*/SKILL.md` — adjust command examples
+3. `CLAUDE.md` — add rules as needed
+
+**Important: never auto-apply.** Allowlist changes affect security, so confirm with the user first.

--- a/.claude/skills/wiki-ingest/SKILL.md
+++ b/.claude/skills/wiki-ingest/SKILL.md
@@ -1,84 +1,86 @@
 ---
 name: wiki-ingest
-description: ブログ記事を読み込んで Wiki ページを自動生成・更新する
+description: Auto-generate or update wiki pages by ingesting blog posts
 arguments:
   - name: target
-    description: "対象の指定。記事パス（content/posts/...）、カテゴリ名、または 'all'（全記事一括）"
+    description: "Target: a post path (`content/posts/...`), a category name, or `all` (batch over every post)"
     required: true
 ---
 
-指定されたブログ記事を読み込み、Wiki ページ（コンセプト・ツール・ガイド）を自動生成・更新します。
+Read the specified blog posts and auto-generate or update the wiki pages (concepts / tools / guides).
 
-## Wiki ページの分類基準
+## Wiki page classification
 
-### concepts/ — 技術概念・用語
+### `concepts/` — technical concepts and terminology
 
-- 技術的な概念、パターン、アーキテクチャの解説
-- 例: RAG、プロンプトエンジニアリング、ゼロトラスト、マイクロサービス
-- ファイル名: `<concept-slug>.md`
+- Explanations of technical concepts, patterns, and architectures.
+- Examples: RAG, prompt engineering, zero trust, microservices.
+- Filename: `<concept-slug>.md`
 
-### tools/ — ツール・サービス・ライブラリ
+### `tools/` — tools, services, libraries
 
-- 具体的なツール、サービス、フレームワーク、ライブラリの情報
-- 例: Claude Code、Hugo、Docker、Terraform
-- ファイル名: `<tool-slug>.md`
+- Concrete tools, services, frameworks, libraries.
+- Examples: Claude Code, Hugo, Docker, Terraform.
+- Filename: `<tool-slug>.md`
 
-### guides/ — How-to・手順まとめ
+### `guides/` — how-tos / consolidated procedures
 
-- 複数記事にまたがる実践的な手順や設定のまとめ
-- 例: Hugo + GitHub Pages セットアップ、Claude Code カスタマイズ
-- ファイル名: `<guide-slug>.md`
+- Practical procedures and configuration sequences that span multiple posts.
+- Examples: Hugo + GitHub Pages setup, Claude Code customisation.
+- Filename: `<guide-slug>.md`
 
-## Wiki ページのフロントマター
+## Wiki page frontmatter
 
 ```yaml
 ---
 title: "ページタイトル"
 description: "1行の概要説明"
-date: YYYY-MM-DD        # 初回作成日
-lastmod: YYYY-MM-DD     # 最終更新日
-aliases: ["別名1", "別名2"]  # 検索用の別名（オプション）
-related_posts:           # ソースとなったブログ記事
+date: YYYY-MM-DD        # creation date
+lastmod: YYYY-MM-DD     # last update date
+aliases: ["別名1", "別名2"]  # search aliases (optional)
+related_posts:          # source blog posts
   - "/posts/YYYY/MM/slug/"
-tags: ["tag1", "tag2"]   # 関連タグ
+tags: ["tag1", "tag2"]  # related tags
 ---
 ```
 
-## Ingest 処理の手順
+> Frontmatter string fields (`title`, `description`, `aliases`) are written in Japanese — wiki pages themselves are Japanese.
 
-### 1. 対象記事を特定する
+## Ingest procedure
 
-- **記事パス指定**: そのファイルを読み込む
-- **カテゴリ指定**: `content/posts/` から該当カテゴリの記事を検索
-- **`all`**: `content/posts/` の全記事を対象にする（バッチ処理）
+### 1. Identify the target posts
 
-### 2. 記事を分析する
+- **Post-path arg**: read that file.
+- **Category arg**: scan `content/posts/` for posts in that category.
+- **`all`**: target every post under `content/posts/` (batch mode).
 
-各記事について以下を抽出する:
+### 2. Analyse each post
 
-- **キーエンティティ**: 記事で主に扱っている概念、ツール、手順
-- **カテゴリとタグ**: フロントマターから取得
-- **要約**: 記事の主要な情報を3-5文で要約
+For each post, extract:
 
-### 3. Wiki ページを生成・更新する
+- **Key entities**: the concepts, tools, and procedures the post is mainly about.
+- **Category and tags**: read from the frontmatter.
+- **Summary**: a 3–5 sentence summary of the main information.
 
-抽出したエンティティごとに:
+### 3. Generate / update wiki pages
 
-1. **既存ページの確認**: `content/wiki/` 内に該当ページが既にあるか検索
-2. **新規作成**: なければ適切なサブディレクトリにページを作成
-3. **更新**: あれば `related_posts` に記事を追加し、内容を補完・更新
-4. **相互参照**: 関連する Wiki ページ同士をリンクで繋ぐ
+For each extracted entity:
 
-### 4. Wiki ページの内容構成
+1. **Check for an existing page** under `content/wiki/` matching the entity.
+2. **Create** a new page in the appropriate subdirectory if none exists.
+3. **Update** by appending to `related_posts` and merging new information into the body.
+4. **Cross-link** related wiki pages to each other.
+
+### 4. Wiki page body structure
 
 ```markdown
 ## 概要
 
-{エンティティの簡潔な説明 — 2-3文}
+{2–3 sentence concise description of the entity}
 
 ## 詳細
 
-{記事群から抽出した詳細情報}
+{detailed information distilled from the source posts}
 
 ## 関連ページ
 
@@ -89,22 +91,24 @@ tags: ["tag1", "tag2"]   # 関連タグ
 - [記事タイトル](/blogs/posts/YYYY/MM/slug/) — YYYY-MM-DD
 ```
 
-### 5. インデックスの更新
+> Section headings inside wiki pages stay Japanese (`概要`, `詳細`, `関連ページ`, `ソース記事`) — they are reader-facing.
 
-処理完了後、各セクションの `_index.md` のリンクが最新状態であることを確認する。
+### 5. Index update
 
-## バッチ処理（`all` 指定時）
+After processing, verify that each section's `_index.md` reflects the latest links.
 
-全記事を一括処理する場合:
+## Batch mode (`all`)
 
-1. カテゴリごとにグループ化して処理する
-2. 1カテゴリ処理するごとに進捗を報告する
-3. 重複するエンティティは統合する
-4. 処理完了後に全体の統計を報告する（作成ページ数、更新ページ数）
+When processing every post:
 
-## 注意事項
+1. Group by category before processing.
+2. Report progress after finishing each category.
+3. Merge duplicate entities.
+4. Report final statistics (pages created / updated).
 
-- Wiki ページは日本語で記述する
-- 記事の内容を丸ごとコピーしない — 要約・統合して知識として再構成する
-- 1つの Wiki ページが長くなりすぎないようにする（目安: 200行以内）
-- `hugo --gc` でビルドが通ることを確認する
+## Notes
+
+- **Wiki pages are written in Japanese.**
+- Do NOT copy whole post bodies verbatim — summarise and integrate into reusable knowledge.
+- Keep a single wiki page from growing too long (rule of thumb: ≤ 200 lines).
+- Verify the Hugo build with `hugo --gc`.

--- a/.claude/skills/wiki-lint/SKILL.md
+++ b/.claude/skills/wiki-lint/SKILL.md
@@ -1,52 +1,52 @@
 ---
 name: wiki-lint
-description: Wiki の健全性チェック（矛盾検出、孤立ページ、欠落リンク、古い記述）
+description: Health-check the wiki — inconsistencies, orphan pages, broken links, stale entries
 arguments: []
 ---
 
-Wiki ナレッジベースの健全性をチェックし、問題を報告・修正します。
+Inspect the wiki knowledge base for problems and report (and optionally fix) them.
 
-## チェック項目
+## Checks
 
-### 1. 孤立ページ検出
+### 1. Orphan page detection
 
-他のどの Wiki ページからもリンクされていないページを検出する。
+Find wiki pages that no other wiki page links to.
 
-- `content/wiki/` 内の全ページを走査
-- 各ページの「関連ページ」セクションのリンク先を収集
-- どこからもリンクされていないページをリストアップ
+- Scan every page under `content/wiki/`.
+- Collect the link targets in each page's "関連ページ" section.
+- List the pages that nobody links to.
 
-### 2. 欠落リンク検出
+### 2. Broken link detection
 
-Wiki ページ内のリンクが存在しないページを指している場合を検出する。
+Find wiki-internal links that point at non-existent pages.
 
-- 各ページの内部リンク（`/blogs/wiki/...`）を抽出
-- リンク先のファイルが `content/wiki/` に存在するか確認
-- 存在しないリンクをリストアップ
+- Extract internal links (`/blogs/wiki/...`) from each page.
+- Confirm the target file exists under `content/wiki/`.
+- List the dangling links.
 
-### 3. related_posts の検証
+### 3. `related_posts` validation
 
-`related_posts` フロントマターで参照しているブログ記事が実在するか確認する。
+Confirm that every `related_posts` entry refers to an existing blog post.
 
-- 各 Wiki ページの `related_posts` を抽出
-- 対応する `content/posts/` のファイルが存在するか確認
-- 存在しない参照をリストアップ
+- Extract `related_posts` from each wiki page's frontmatter.
+- Confirm the corresponding `content/posts/` file exists.
+- List the dangling references.
 
-### 4. 古い記述の検出
+### 4. Staleness detection
 
-`lastmod` が古い Wiki ページで、ソース記事が更新されている可能性があるものを検出する。
+Find wiki pages whose `lastmod` is older than their source posts.
 
-- Wiki ページの `lastmod` と `related_posts` の記事の `lastmod` を比較
-- 記事のほうが新しい場合、Wiki ページの更新が必要な可能性をフラグ
+- For each wiki page, compare its `lastmod` against the `lastmod` of every post in `related_posts`.
+- Flag any wiki page that is older than its source — it likely needs refreshing.
 
-### 5. フロントマター整合性
+### 5. Frontmatter completeness
 
-必須フロントマター項目が欠落しているページを検出する。
+Find pages missing required frontmatter fields.
 
-- 必須: title, description, date, lastmod, related_posts, tags
-- 推奨: aliases
+- Required: `title`, `description`, `date`, `lastmod`, `related_posts`, `tags`.
+- Recommended: `aliases`.
 
-## 出力フォーマット
+## Output format
 
 ```markdown
 ## Wiki Lint レポート
@@ -71,14 +71,16 @@ Wiki ページ内のリンクが存在しないページを指している場合
 - concepts: XX / tools: XX / guides: XX
 ```
 
-## 修正の提案
+> The report is user-facing, so its headings and prose stay Japanese.
 
-問題が見つかった場合、以下の対応を提案する:
+## Suggested fixes
 
-- **孤立ページ**: 関連する Wiki ページに相互リンクを追加
-- **欠落リンク**: リンク先ページの作成、またはリンクの削除
-- **related_posts 不整合**: 正しいパスに修正、または参照を削除
-- **古いページ**: `/wiki-ingest` でソース記事を再読み込みして更新
-- **フロントマター不備**: 欠落項目を補完
+When problems are found, suggest:
 
-ユーザーの確認後に修正を実施する。
+- **Orphan page** → add a reciprocal link from a related wiki page.
+- **Broken link** → create the missing target page, or remove the link.
+- **`related_posts` mismatch** → correct the path, or drop the reference.
+- **Stale page** → re-run `/wiki-ingest` against the source post.
+- **Missing frontmatter** → fill in the missing fields.
+
+Apply fixes only after the user confirms.


### PR DESCRIPTION
## 概要

#393 で実装した CLAUDE.md 英語化と同じ方針で、`.claude/skills/*/SKILL.md` の 4 ファイルを英語化した。

prompt caching が効く固定資産（SKILL.md）を英語化することで、各スキル実行時の入力トークンを構造的に削減する。

## 対象ファイル

- `.claude/skills/blog/SKILL.md` (361 行 → 357 行)
- `.claude/skills/wiki-ingest/SKILL.md`
- `.claude/skills/wiki-lint/SKILL.md`
- `.claude/skills/permission-review/SKILL.md`

## 翻訳方針

| 要素 | 言語 | 理由 |
|---|---|---|
| 見出し・規約・手順説明・コメント | 英語 | キャッシュヒット対象。LLM への指示として最適 |
| ユーザー向けエラーメッセージ | 日本語維持 | 例: `「エラー: このスキルで受け付ける URL は...」` |
| 出力レポートの見出し・例 | 日本語維持 | `## 分析結果`、`### 孤立ページ (X件)` など、ユーザー向け出力 |
| フロントマター例の `title`/`description` | 日本語維持 | wiki ページ・ブログ記事本体が日本語のため |
| Agent 呼び出しプロンプト例 | 日本語維持 | `Agent(... prompt="以下の記事をレビューしてください: ...")` のように、Agent への指示も日本語のまま |
| `## 概要`/`## 詳細` などのテンプレ見出し | 日本語維持 | wiki ページの本文構造を維持 |
| カテゴリ名 | 日本語維持 | `scripts/categorize.py` の文字列マッチ実値 |

## 仕様の変更はゼロ

- コマンド・パス・手順・引数はすべて不変
- スキルの動作仕様（URL allowlist、ファクトチェック手順、worktree パターン等）は完全に同等
- diff の中身は **言語の置き換えのみ**

## テスト

- `hugo --gc` ビルド成功（SKILL.md は Hugo 対象外だが念のため）
- 翻訳マーカー（`<<<<<<<` 等）残存なし

## 関連

- 前提となる方針記事: [「言語税」対策として CLAUDE.md を英語化する](/blogs/posts/2026/05/2026-05-13-claude-md-english-prompt-caching/)
- 前段 PR: #393
- 「言語税」の元記事: #372

## 次のステップ

- 実測: 同一タスク（記事 1 本作成）の入力トークン数を Before/After で計測
