### PR TITLE
Fix: blog-batch.sh で wiki-ingest をスキップ — 並行 PR の wiki コンフリクトを回避

### DIFF
--- a/.claude/skills/blog/SKILL.md
+++ b/.claude/skills/blog/SKILL.md
@@ -351,10 +351,11 @@ gh api /repos/{owner}/{repo}/issues/{issue_number}/comments \
    git worktree remove --force "$WORKTREE_DIR"
    ```
 3. **Wiki auto-ingest check**: after merge, decide whether to run `/wiki-ingest`:
-   1. Read the last ingest date from `.claude/wiki-last-ingest.txt` (default `1970-01-01` if missing).
-   2. Count posts in `content/posts/` whose frontmatter `date` is on or after that date.
-   3. **≥ 20 posts**: auto-run `/wiki-ingest all`, then update `.claude/wiki-last-ingest.txt` to today.
-   4. **< 20 posts**: just report "Wiki update in N more posts" (do not run ingest).
+   1. **Skip-condition check first**: if the caller (e.g. the prompt itself) has explicitly told you to skip Wiki auto-ingest — for example by including text like "Wiki auto-ingest check は実行しないでください" or "/wiki-ingest はスキップ" — do not execute this step at all. This applies whenever `/blog` is invoked from `scripts/blog-batch.sh` or any other automation, because running `/wiki-ingest` inside the same blog branch causes wiki commits to be bundled into every blog PR and creates merge conflicts when multiple blog PRs run in parallel.
+   2. Read the last ingest date from `.claude/wiki-last-ingest.txt` (default `1970-01-01` if missing).
+   3. Count posts in `content/posts/` whose frontmatter `date` is on or after that date.
+   4. **≥ 20 posts**: auto-run `/wiki-ingest all`, then update `.claude/wiki-last-ingest.txt` to today.
+   5. **< 20 posts**: just report "Wiki update in N more posts" (do not run ingest).
 
    ```bash
    # Read the last ingest date
@@ -364,3 +365,5 @@ gh api /repos/{owner}/{repo}/issues/{issue_number}/comments \
    # After running ingest, use the Write tool to set
    # .claude/wiki-last-ingest.txt to today's date.
    ```
+
+   > **Why the skip-condition matters**: a single `/blog` run that triggers `/wiki-ingest all` will add commits to the current blog branch that modify shared wiki files like `content/wiki/concepts/harness-engineering.md` and `content/wiki/tools/claude-code.md`. When `blog-batch.sh` produces many blog branches in parallel, each carrying its own wiki commit, those branches conflict with each other and with `main`. Always let the batch driver decide when to run wiki ingest (via `--final-wiki-ingest`).

--- a/scripts/blog-batch.sh
+++ b/scripts/blog-batch.sh
@@ -5,24 +5,32 @@
 #   ./scripts/blog-batch.sh <issue_number> [options]
 #
 # Options:
-#   --dry-run         ツイート内容を一覧表示するのみ（ブログ作成しない）
-#   --limit N         処理件数の上限（デフォルト: 全件）
-#   --skip-review     ファクトチェック・エージェントレビューを省略（高速化）
-#   --model MODEL     使用モデル（デフォルト: sonnet）
-#   --interval SECS   処理間のインターバル秒数（デフォルト: 5）
-#   --overnight       夜間バッチモード（nohup 相当 + インターバル60秒 + PRサマリー出力）
+#   --dry-run             ツイート内容を一覧表示するのみ（ブログ作成しない）
+#   --limit N             処理件数の上限（デフォルト: 全件）
+#   --skip-review         ファクトチェック・エージェントレビューを省略（高速化）
+#   --model MODEL         使用モデル（デフォルト: sonnet）
+#   --interval SECS       処理間のインターバル秒数（デフォルト: 5）
+#   --overnight           夜間バッチモード（nohup 相当 + インターバル60秒 + PRサマリー出力）
+#   --final-wiki-ingest   全件処理完了後に /wiki-ingest all を 1 回だけ実行
+#
+# Wiki 集約処理について:
+#   /blog スキルの "Post-merge follow-up" には Wiki 自動 ingest チェックが含まれるが、
+#   バッチ実行中はこれを必ずスキップする（各ブランチに wiki コミットが混入し、
+#   並行 PR で同じ wiki ファイル更新が衝突するため）。
+#   バッチ完了後に Wiki を更新したい場合は --final-wiki-ingest を指定する。
 #
 # Examples:
-#   ./scripts/blog-batch.sh 1 --dry-run                     # 未ブログ化一覧を確認
-#   ./scripts/blog-batch.sh 1 --limit 3                     # 3件だけ処理
-#   ./scripts/blog-batch.sh 1 --skip-review --limit 5       # レビュー省略で5件処理
-#   ./scripts/blog-batch.sh 1 --overnight                   # 全件を夜間バッチで処理
-#   ./scripts/blog-batch.sh 1 --overnight --interval 120    # 2分間隔で夜間バッチ
+#   ./scripts/blog-batch.sh 1 --dry-run                            # 未ブログ化一覧を確認
+#   ./scripts/blog-batch.sh 1 --limit 3                            # 3件だけ処理（wiki skip）
+#   ./scripts/blog-batch.sh 1 --skip-review --limit 5              # レビュー省略で5件処理
+#   ./scripts/blog-batch.sh 1 --overnight                          # 全件を夜間バッチで処理
+#   ./scripts/blog-batch.sh 1 --overnight --final-wiki-ingest      # 全件 + バッチ後に wiki ingest
+#   ./scripts/blog-batch.sh 1 --overnight --interval 120           # 2分間隔で夜間バッチ
 
 set -euo pipefail
 
 REPO="hdknr/blogs"
-ISSUE_NUMBER="${1:?Usage: blog-batch.sh <issue_number> [--dry-run] [--limit N] [--skip-review] [--model MODEL] [--interval SECS] [--overnight]}"
+ISSUE_NUMBER="${1:?Usage: blog-batch.sh <issue_number> [--dry-run] [--limit N] [--skip-review] [--model MODEL] [--interval SECS] [--overnight] [--final-wiki-ingest]}"
 shift
 
 # --- オプション解析 ---
@@ -32,16 +40,18 @@ SKIP_REVIEW=false
 MODEL="sonnet"
 INTERVAL=5
 OVERNIGHT=false
+FINAL_WIKI_INGEST=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --dry-run)      DRY_RUN=true; shift ;;
-    --limit)        LIMIT="$2"; shift 2 ;;
-    --skip-review)  SKIP_REVIEW=true; shift ;;
-    --model)        MODEL="$2"; shift 2 ;;
-    --interval)     INTERVAL="$2"; shift 2 ;;
-    --overnight)    OVERNIGHT=true; shift ;;
-    *)              echo "Unknown option: $1"; exit 1 ;;
+    --dry-run)            DRY_RUN=true; shift ;;
+    --limit)              LIMIT="$2"; shift 2 ;;
+    --skip-review)        SKIP_REVIEW=true; shift ;;
+    --model)              MODEL="$2"; shift 2 ;;
+    --interval)           INTERVAL="$2"; shift 2 ;;
+    --overnight)          OVERNIGHT=true; shift ;;
+    --final-wiki-ingest)  FINAL_WIKI_INGEST=true; shift ;;
+    *)                    echo "Unknown option: $1"; exit 1 ;;
   esac
 done
 
@@ -107,6 +117,11 @@ if [[ "$SKIP_REVIEW" == "true" ]]; then
   SKIP_REVIEW_PROMPT="ファクトチェックとエージェントレビュー（tech-writer, seo-advisor）は省略してください。"
 fi
 
+# バッチ実行中は Wiki auto-ingest を必ずスキップする。
+# 各ブランチに wiki ingest コミットが混入すると、同じ wiki ファイルを
+# 複数 PR が並行更新してマージコンフリクトが発生するため。
+SKIP_WIKI_INGEST_PROMPT="重要: SKILL.md の 'Post-merge follow-up' ステップ 3（Wiki auto-ingest check）は実行しないでください。バッチ処理中なので個別 ingest は不要です。Wiki 更新はバッチ完了後にまとめて行います。"
+
 SUCCESS=0
 FAILED=0
 SKIPPED=0
@@ -151,7 +166,8 @@ for i in $(seq 0 $((PROCESS_COUNT - 1))); do
   echo "    ${BODY_PREVIEW}"
 
   # claude -p でブログ作成
-  PROMPT="/blog ${COMMENT_URL}"
+  PROMPT="/blog ${COMMENT_URL}
+${SKIP_WIKI_INGEST_PROMPT}"
   if [[ -n "$SKIP_REVIEW_PROMPT" ]]; then
     PROMPT="${PROMPT}
 ${SKIP_REVIEW_PROMPT}"
@@ -253,4 +269,34 @@ if [[ ${#PR_URLS[@]} -gt 0 ]]; then
   for pr in "${PR_URLS[@]}"; do
     echo "  ${pr}"
   done
+fi
+
+# --- 最終 Wiki ingest（オプション） ---
+if [[ "$FINAL_WIKI_INGEST" == "true" ]] && [[ "$SUCCESS" -gt 0 ]]; then
+  echo ""
+  echo "=== 最終 Wiki ingest 実行中 $(date '+%H:%M:%S') ==="
+  WIKI_RESULT_FILE=".claude/temp/blog-batch-wiki-${TIMESTAMP}.txt"
+  if claude -p \
+    --model "$MODEL" \
+    --dangerously-skip-permissions \
+    --max-budget-usd 5.00 \
+    "/wiki-ingest all" \
+    > "$WIKI_RESULT_FILE" 2>&1; then
+    echo "✅ Wiki ingest 完了"
+    echo "" >> "$REPORT_FILE"
+    echo "## Wiki ingest" >> "$REPORT_FILE"
+    echo "" >> "$REPORT_FILE"
+    echo "- ステータス: ✅ 成功" >> "$REPORT_FILE"
+    echo "- 完了時刻: $(date '+%Y-%m-%d %H:%M:%S')" >> "$REPORT_FILE"
+  else
+    EXIT_CODE=$?
+    echo "❌ Wiki ingest 失敗 (exit code: ${EXIT_CODE})"
+    echo "" >> "$REPORT_FILE"
+    echo "## Wiki ingest" >> "$REPORT_FILE"
+    echo "" >> "$REPORT_FILE"
+    echo "- ステータス: ❌ 失敗 (exit ${EXIT_CODE})" >> "$REPORT_FILE"
+    echo "- 結果ログ: ${WIKI_RESULT_FILE}" >> "$REPORT_FILE"
+  fi
+  echo "=== Wiki ingest ログ ===" >> "$LOG_FILE"
+  cat "$WIKI_RESULT_FILE" >> "$LOG_FILE" 2>/dev/null
 fi


### PR DESCRIPTION
## 概要

`blog-batch.sh` で複数のブログ PR を並行作成すると、各ブランチに `/wiki-ingest all` の結果コミットが混入し、共通の wiki ファイル（`content/wiki/concepts/harness-engineering.md`、`content/wiki/tools/claude-code.md` 等）が複数 PR で同時更新されて main へのマージ時にコンフリクトが多発していた。

実際 #368 / #369 / #371 / #372 はいずれもこのパターンで wiki ファイルがコンフリクトし、手動で main 側採用の解消作業が必要だった。

## 根本原因

`/blog` スキルの "Post-merge follow-up" セクション内 Wiki auto-ingest check が、**PR マージ前**（つまり `claude -p` セッション内）で発火していた。SKILL.md の意図は "after merge" だが、単一 `claude -p` 呼び出しではマージ待ちができないため、すぐに ingest を実行 → 結果コミットが blog ブランチに混入していた。

## 修正内容

### `scripts/blog-batch.sh`

1. 各 `/blog` 呼び出しのプロンプトに **Wiki auto-ingest スキップ指示** を必ず付与:
   ```
   重要: SKILL.md の 'Post-merge follow-up' ステップ 3（Wiki auto-ingest check）は実行しないでください。
   バッチ処理中なので個別 ingest は不要です。Wiki 更新はバッチ完了後にまとめて行います。
   ```
2. **`--final-wiki-ingest` フラグ** を追加: バッチで全件処理完了後に **1 回だけ** `/wiki-ingest all` を実行（成功 1 件以上の場合のみ）。
3. usage / examples / コメントを更新。

### `.claude/skills/blog/SKILL.md`

"Post-merge follow-up" の Wiki auto-ingest check に **skip-condition** を明記:

> If the caller has explicitly told you to skip Wiki auto-ingest, do not execute this step at all.
> This applies whenever `/blog` is invoked from `scripts/blog-batch.sh` or any other automation,
> because running `/wiki-ingest` inside the same blog branch causes wiki commits to be bundled
> into every blog PR and creates merge conflicts when multiple blog PRs run in parallel.

## テスト

- `bash -n scripts/blog-batch.sh` → syntax OK
- 引数なし実行で usage 表示確認

## 関連

- 直近で wiki コンフリクトが発生した PR: #368 / #369 / #371 / #372（すべて main 側採用で手動解消済み）
- 「言語税」シリーズ: #393 / #394 / #395

## 運用イメージ（修正後）

```bash
# 夜間バッチで 20 件処理、最後に Wiki もまとめて更新
nohup ./scripts/blog-batch.sh 1 --overnight --final-wiki-ingest \
  > .claude/temp/blog-batch-stdout.log 2>&1 &
```
