### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ resources/_gen/
 # knowl: Claude Code 個人環境依存
 .claude/knowledge
 .claude/settings.local.json
+# macOS
+.DS_Store


### PR DESCRIPTION
## 概要

macOS が生成する `.DS_Store` を `.gitignore` に追加します。`static/.DS_Store` 等が作業ツリーに untracked で現れるのを抑止します。

- 既存の `# macOS` カテゴリとして1行追加
- 既にコミットされたものは無いため、ignore 追加のみで対応
