### PR TITLE
Fix malformed URLs (broken autolink/citation artifacts)

### DIFF
--- a/content/posts/2024/03/2024-03-14-05df197941702710ea55013287157a16.md
+++ b/content/posts/2024/03/2024-03-14-05df197941702710ea55013287157a16.md
@@ -28,7 +28,7 @@ tags: ["rag"]
 
 ## 仕組み
 
-- https://docs.aws.amazon.com/ja_j p/bedrock/latest/userguide/kb-how-it-works.html
+- https://docs.aws.amazon.com/ja_jp/bedrock/latest/userguide/kb-how-it-works.html
 
 RAG:
 

--- a/content/posts/2024/10/2024-10-04-2a9f66260290a10756ad905ebb707116.md
+++ b/content/posts/2024/10/2024-10-04-2a9f66260290a10756ad905ebb707116.md
@@ -77,7 +77,7 @@ Sparse Vector（スパースベクトル）は、**高次元のベクトル**で
 
 ### 特徴
 
-- **高次元**：スパースベクトルは通常、非常に多くの次元を持ちますが、その中で非ゼロの要素はごくわずかです[¹](https://qdrant.tech/articles/sparse-vectors/)²(<https://www.pinecone.io/learn/splade/)。>
+- **高次元**：スパースベクトルは通常、非常に多くの次元を持ちますが、その中で非ゼロの要素はごくわずかです[¹](https://qdrant.tech/articles/sparse-vectors/)[²](https://www.pinecone.io/learn/splade/)。
 - **効率的なメモリ使用**：非ゼロの要素が少ないため、メモリとストレージの使用が効率的です[³](https://zilliz.com/learn/everything-you-should-know-about-vector-embeddings)。
 - **解釈可能性**：各次元が特定の単語やトークンに対応しているため、ベクトルの意味を解釈しやすいです[¹](https://qdrant.tech/articles/sparse-vectors/)。
 

--- a/content/posts/2024/10/2024-10-11-d73630b702b019970f93f48d4fa6dbe2.md
+++ b/content/posts/2024/10/2024-10-11-d73630b702b019970f93f48d4fa6dbe2.md
@@ -36,7 +36,7 @@ max_requests_jitter = 50  # 再起動タイミングをランダム化
 gunicorn --max-requests 1000 --max-requests-jitter 50 myapp:app
 ```
 
-これにより、各ワーカープロセスは1000回のリクエストを処理した後、ランダムに最大50回のリクエストを追加で処理してから再起動されます¹(<https://qiita.com/ryu22e/items/2668a2243a5191bcdc78)²(https://zenn.dev/xknzw/articles/d2d337ae2f8966)³(https://qiita.com/_konishi_/items/1dc2bbfc386f57d06934)。>
+これにより、各ワーカープロセスは1000回のリクエストを処理した後、ランダムに最大50回のリクエストを追加で処理してから再起動されます[¹](https://qiita.com/ryu22e/items/2668a2243a5191bcdc78)[²](https://zenn.dev/xknzw/articles/d2d337ae2f8966)[³](https://qiita.com/_konishi_/items/1dc2bbfc386f57d06934)。
 
 この設定により、メモリリークの影響を最小限に抑えつつ、サービスの安定性を保つことができます。
 

--- a/content/posts/2026/03/2026-03-04-6560f5a15f932961806301b459e32150.md
+++ b/content/posts/2026/03/2026-03-04-6560f5a15f932961806301b459e32150.md
@@ -254,6 +254,6 @@ Fowler のチームの結論は「Spec-first の原則は有効だが、現在�
 - [Birgitta Böckeler — Understanding Spec-Driven-Development: Kiro, spec-kit, and Tessl（Martin Fowler）](https://martinfowler.com/articles/exploring-gen-ai/sdd-3-tools.html)
 - [Swiss Cheese Model for AI Safety — arXiv](https://arxiv.org/abs/2408.02205)
 - [Adversarial Code Review — ASDLC.io](https://asdlc.io/patterns/adversarial-code-review/)
-- [Spec-Driven Development — Wikipedia](https://en.wikipedia.org/wiki/Spec-driven-development)
+- [Spec-Driven Development — Wikipedia](https://en.wikipedia.org/wiki/Spec-driven_development)
 - [Zencoder — A Practical Guide to Spec-Driven Development](https://docs.zencoder.ai/user-guides/tutorials/spec-driven-development-guide)
 - [r_kaga — そのAI生成コード、全部レビューしますか？（Zenn）](https://zenn.dev/r_kaga/articles/66c190413d3ab9)


### PR DESCRIPTION
## 概要

Phase 2（外部リンク）の一部として、**URL 自体が壊れているレンダリングバグ 4 件を修正**します。いずれも AI 生成の引用アーティファクトや取り込み時の破損で、リンクとして機能していませんでした。純粋なリンク切れ（URL は正しいが先が消滅）とは別枠で、まず「壊れた URL」だけを対象にしています。

## 修正

| ファイル | 症状 | 修正 |
|---|---|---|
| `2024/03/…05df1979….md` | `docs.aws.amazon.com/ja_j p/…`（URL 内にスペース混入で分断） | `ja_jp` に修正 |
| `2024/10/…2a9f6626….md` | `[¹](…)²(<…/splade/)。>`（オートリンクに `)。` 混入） | `[¹](…)[²](…)。` の正しい脚注記法へ |
| `2024/10/…d73630b7….md` | `¹(<url)²(url)³(url)。>`（複数 URL がオートリンクに融合） | `[¹](…)[²](…)[³](…)。` へ分離 |
| `2026/03/…6560f5a1….md` | Wikipedia `Spec-driven-development`（ハイフン）→ 404 | `Spec-driven_development`（アンダースコア、200 確認済み）へ |

## 検証

- 各修正後の URL/記法が有効であることを確認（Wikipedia はアンダースコア版が 200）。
- main の lychee 内部リンクチェック（PR ジョブ）で退行が無いことを確認予定。

## Phase 2 の残り（別途）

- 純粋なリンク切れ（URL は正しいが先が消滅）—— 主に 2015–2019 の古記事。これは週次 external sweep（#536）で継続追跡し、方針を別途相談。
- bot ブロック誤検知（Bloomberg / Salesforce / MySQL docs 等）は `lychee-external.toml` で除外済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
