### PR TITLE
Fix external link sweep noise (root-relative false errors)

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -112,22 +112,48 @@ jobs:
           TZ: Asia/Tokyo
         run: hugo --gc --minify --baseURL "https://hdknr.github.io/blogs/"
 
+      - name: Mirror to /blogs base path
+        run: |
+          mkdir -p _site/blogs
+          cp -a public/. _site/blogs/
+
+      - name: Serve site locally
+        run: |
+          nohup python3 -c "
+          from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
+          import functools
+          h = functools.partial(SimpleHTTPRequestHandler, directory='_site')
+          ThreadingHTTPServer(('127.0.0.1', 8099), h).serve_forever()
+          " >/dev/null 2>&1 &
+          for i in $(seq 1 30); do
+            curl -sf -o /dev/null http://127.0.0.1:8099/blogs/ && break
+            sleep 0.5
+          done
+
+      - name: Install lychee
+        run: |
+          wget -O /tmp/lychee.tar.gz \
+            "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz"
+          mkdir -p /tmp/lychee-bin
+          tar -xzf /tmp/lychee.tar.gz -C /tmp/lychee-bin
+          sudo mv "$(find /tmp/lychee-bin -type f -name lychee | head -1)" /usr/local/bin/lychee
+          lychee --version
+
+      # Internal links resolve to the local server (base_url/remap in the
+      # config) and are excluded, so only genuine EXTERNAL links are checked.
       - name: Check external links
         id: lychee
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: >-
-            --no-progress
-            --config lychee-external.toml
-            --scheme https
-            --scheme http
-            --exclude "^https?://hdknr\.github\.io/"
-            './public/**/*.html'
-          fail: false
-          output: ./lychee/report.md
+        run: |
+          mkdir -p lychee
+          set +e
+          lychee --no-progress --config lychee-external.toml \
+            --output ./lychee/report.md \
+            './_site/blogs/**/*.html'
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          set -e
 
       - name: Open issue on dead links
-        if: steps.lychee.outputs.exit_code != 0
+        if: steps.lychee.outputs.exit_code != '0'
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "Dead links detected by weekly lychee sweep"

--- a/lychee-external.toml
+++ b/lychee-external.toml
@@ -1,26 +1,34 @@
-# lychee configuration — used by the weekly external-link sweep in
+# lychee configuration — used by the weekly EXTERNAL-link sweep in
 # .github/workflows/linkcheck.yml
 #
-# Rationale: many hosts return 403/429/400 to non-browser clients (bot
-# protection, rate limits) even though the page is perfectly reachable in a
-# browser. Treating those as "dead" produces false positives, so we:
-#   1. exclude the worst offenders outright, and
-#   2. accept transient/soft-block status codes as OK.
-# The PR-time internal check does NOT use this file (it only checks localhost).
+# The external job builds the site, mirrors it under the /blogs/ base path and
+# serves it on http://127.0.0.1:8099/. This config then:
+#   - resolves internal links to that local server (base_url + remap) so
+#     root-relative assets like /blogs/assets/…css do NOT error, and
+#   - EXCLUDES the local server, so only genuine EXTERNAL links are checked.
+#
+# Many hosts return 403/429/5xx to non-browser clients (bot protection, rate
+# limits) even though the page is reachable in a browser. To keep the weekly
+# report actionable we accept those soft-block/transient codes and report only
+# hard-dead links. The PR-time internal check does NOT use this file.
 
-# Accept soft-block / partial-content codes as reachable.
-accept = [200, 206, 403, 429]
+# Resolve internal links against the local mirror server.
+base_url = "http://127.0.0.1:8099/"
+remap = ["https://hdknr.github.io/ http://127.0.0.1:8099/"]
 
-# Retry transient failures before giving up.
+# Accept soft-block / partial-content / transient codes as reachable so the
+# report is dominated by real dead links (404/410), not bot walls.
+accept = ["200", "206", "403", "429", "500", "503"]
+
 max_retries = 2
 retry_wait_time = 3
 timeout = 20
-
-# Be gentle: some hosts rate-limit aggressively.
 max_concurrency = 8
 
-# Hosts that reliably block crawlers (verified reachable in a browser).
 exclude = [
+  # Internal: served locally; only external links should be checked here.
+  "^http://127\\.0\\.0\\.1:8099/",
+  # Hosts that reliably block crawlers (verified reachable in a browser).
   "^https?://(www\\.)?bloomberg\\.com/",
   "^https?://(www\\.)?axios\\.com/",
   "^https?://tabelog\\.com/",
@@ -44,4 +52,6 @@ exclude = [
   "^https?://zhuanlan\\.zhihu\\.com/",
   "^https?://(developers|access)\\.redhat\\.com/",
   "^https?://app\\.getzep\\.com/",
+  # X/Twitter: returns 404 to bots for valid tweets (SPA).
+  "^https?://(x|twitter)\\.com/",
 ]


### PR DESCRIPTION
## 概要

週次 external link sweep が**誤検知だらけ**だった不具合を修正します。手動起動（#540）で「3275 errors」が出ましたが、その大半は実在するリンク切れではなく、`public/**/*.html` を直接検査したことによる **root-relative アセット（`/blogs/assets/…css` 等）の解決不能エラー**でした（全ページで同一エラーが発生）。

## 原因

external ジョブは lychee を `./public/**/*.html` に直接かけていた。base path が `/blogs/` のため、各ページの `/blogs/assets/...css` のような root-relative リンクを lychee が解決できず（`Error building URL ... provide a root dir`）、ページ数ぶんのエラーが量産されていた。真の外部リンク切れはノイズに埋もれ、Issue も truncate されて実質使えなかった。

さらに lychee-action は Docker 上で動くためローカルサーバ（localhost）に到達できず、mirror+serve 方式と両立しなかった。

## 修正

internal ジョブと同じ **mirror + ローカルサーブ**方式に統一し、lychee を CLI で直接実行（Docker 回避）:

1. ビルド → `_site/blogs/` にミラー → `127.0.0.1:8099` でサーブ（本番同等の base path）
2. `lychee-external.toml` で内部リンクを localhost に解決（`base_url` + `remap`）**かつ除外**し、**外部リンクだけを検査**
3. bot ブロック常習ホスト（Bloomberg・Salesforce・X 等）を除外、transient コード（403/429/5xx）を accept して**ハードな 404/410 だけ**が残るように

## 検証（ローカル）

lychee 0.24.2 で修正後の設定を実ページに適用:

- ホームページ（内部 CSS/ナビ多数）→ **0 エラー**（従来はここで大量の CSS 誤検知）
- `graphite-stacked-prs-merge-queue` 記事 → 実在する `https://graphite.com/docs/stacked-prs` の **404 を正しく検出**（91 除外・11 OK・1 実エラー）

## 補足

- ノイズだった Issue #540 はこの修正で不要になるためクローズします。マージ後に手動起動すれば、actionable な外部リンク切れ一覧が改めて起票されます。
- internal ジョブ（PR ブロッキング）は変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
