### PR TITLE
Run Link check once per PR: draft-first flow and /ship skill

### DIFF
--- a/.claude/skills/blog/SKILL.md
+++ b/.claude/skills/blog/SKILL.md
@@ -284,16 +284,17 @@ After drafting the post, open a PR following this procedure.
    git -C "$WORKTREE_DIR" commit -m "Add blog post: <post-title-in-Japanese>"
    git -C "$WORKTREE_DIR" push -u origin "$BRANCH_NAME"
    ```
-7. Create the PR (explicitly pin the branch with `--head` and avoid `cd`):
+7. Create the PR **as a draft** (explicitly pin the branch with `--head` and avoid `cd`):
    Write the PR body to a file inside the worktree, then pass it via `--body-file`. The worktree is outside `.claude/`, so the Write tool can write to it directly.
    ```bash
    # Use the Write tool to write the PR body to $WORKTREE_DIR/pr_body.md
-   gh pr create --repo hdknr/blogs --head "$BRANCH_NAME" --title "Add blog: <post-title-in-Japanese>" --body-file "$WORKTREE_DIR/pr_body.md"
+   gh pr create --repo hdknr/blogs --draft --head "$BRANCH_NAME" --title "Add blog: <post-title-in-Japanese>" --body-file "$WORKTREE_DIR/pr_body.md"
    ```
+   **`--draft` is mandatory.** `linkcheck.yml` triggers on `pull_request: [ready_for_review, reopened]`, not on every push. Creating the PR as a draft means the Link check runs **once**, when `/ship` marks it ready — instead of once per intermediate push during review and follow-up edits.
    **Note: do not use `cd "$WORKTREE_DIR" && gh pr create`.** Commands that start with `cd` do not match the `Bash(gh:*)` allowlist pattern and trigger a prompt every time. As long as you pass `--head`, you do not need to be inside the worktree.
    **Note: do not use the `--body "$(cat <<'EOF'...)"` style.** Lines starting with `#` inside the HEREDOC trip a security check ("quoted newline followed by #-prefixed line") and trigger a prompt every time.
 8. Note the PR URL (used when linking back to the source).
-9. **Remove the worktree once the PR is merged.** When the user confirms the merge, run `git worktree remove --force "$WORKTREE_DIR"` (the `--force` is needed because of untracked files like `pr_body.md`).
+9. **Hand off to `/ship` — do not merge or clean up here.** Tell the user the PR is a draft and that `/ship <PR-number>` will take it through ready → CI → merge → worktree removal → Wiki ingest check. Follow-up edits requested by the user are pushed to the same draft branch; because the PR is still a draft, those pushes do not fire CI.
 
 ## Link back to source + 🚀-reaction mark
 
@@ -348,19 +349,21 @@ gh api /repos/{owner}/{repo}/issues/{issue_number}/comments \
 
 > The announcement comment body is written in Japanese — it is user-facing.
 
-## Post-merge follow-up
+## Handing off to `/ship`
 
-1. Send the PR URL to the user.
-2. After merge, auto-remove the worktree (force-remove because of untracked files like `pr_body.md`):
-   ```bash
-   git worktree remove --force "$WORKTREE_DIR"
-   ```
-3. **Wiki auto-ingest check**: after merge, decide whether to run `/wiki-ingest`:
-   1. **Skip-condition check first**: if the caller (e.g. the prompt itself) has explicitly told you to skip Wiki auto-ingest — for example by including text like "Wiki auto-ingest check は実行しないでください" or "/wiki-ingest はスキップ" — do not execute this step at all. This applies whenever `/blog` is invoked from `scripts/blog-batch.sh` or any other automation, because running `/wiki-ingest` inside the same blog branch causes wiki commits to be bundled into every blog PR and creates merge conflicts when multiple blog PRs run in parallel.
-   2. Read the last ingest date from `.claude/wiki-last-ingest.txt` (default `1970-01-01` if missing).
-   3. Count posts in `content/posts/` whose frontmatter `date` is on or after that date.
-   4. **≥ 20 posts**: auto-run `/wiki-ingest all`, then update `.claude/wiki-last-ingest.txt` to today.
-   5. **< 20 posts**: just report "Wiki update in N more posts" (do not run ingest).
+`/blog` ends at "draft PR created, source marked with 🚀". It does **not** mark the PR
+ready, wait for CI, merge, remove the worktree, or run the Wiki ingest check — all of that
+lives in `/ship` (`.claude/skills/ship/SKILL.md`).
+
+1. Send the PR URL to the user and state that it is a **draft**.
+2. Tell them `/ship <PR-number>` runs ready → Link check → merge → worktree removal →
+   Wiki ingest check as one sequence.
+3. If the user asks for follow-up edits, push them to the same branch. The PR is still a
+   draft, so those pushes do not fire CI — which is the entire point of the split.
+
+> Why the split: `linkcheck.yml` triggers on `pull_request: [ready_for_review, reopened]`.
+> Keeping the PR in draft during drafting and review means the Link check runs once, at
+> ship time, instead of once per push.
 
    ```bash
    # Read the last ingest date

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -66,9 +66,14 @@ gh pr ready $PR --repo hdknr/blogs
 
 ### 3. Wait for the Link check
 
-Run as a **background** Bash call. The `length > 0` guard is essential: immediately after
-`gh pr ready`, GitHub has not registered the run yet and an unguarded "nothing is pending"
-test would pass instantly.
+Run as a **background** Bash call. Two properties of this loop are load-bearing:
+
+- The `length > 0` guard: immediately after `gh pr ready`, GitHub has not registered the run
+  yet, and an unguarded "nothing is pending" test would pass instantly.
+- The comparison is **positive** (`= "done"`), never negative (`!= "OPEN"`-style). A
+  transient `gh` failure produces an empty string, which must mean *keep waiting*. A
+  negated test treats that empty string as "condition met" and exits with a false positive
+  — silently skipping the CI gate. Always write poll conditions so that "no answer" loops.
 
 ```bash
 until [ "$(gh pr checks $PR --repo hdknr/blogs --json bucket --jq 'if length > 0 and (all(.[]; .bucket != "pending")) then "done" else "wait" end' 2>/dev/null)" = "done" ]; do sleep 20; done

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: ship
+description: Take a draft PR through ready → CI → merge → cleanup in one pass
+arguments:
+  - name: pr
+    description: PR number to ship (e.g. 599). Required.
+---
+
+Ship a pull request: flip it out of draft, wait for the Link check to finish, merge it
+only if the check passed, then do the post-merge cleanup.
+
+This exists because `linkcheck.yml` triggers on `pull_request: [ready_for_review, reopened]`
+rather than on every push. The check is meant to run **once per PR, at the moment the PR
+becomes mergeable** — which makes "ready", "CI", and "merge" a single sequence rather than
+three things the user has to drive by hand.
+
+## Preconditions
+
+- `$PR` is the PR number passed as the argument. Abort with a Japanese error if absent:
+  「エラー: PR 番号を指定してください（例: /ship 599）。」
+- Only operate on `hdknr/blogs`. Always pass `--repo hdknr/blogs` explicitly.
+- **Never merge a PR whose Link check failed.** Report and stop instead.
+
+## Mandatory Bash rules
+
+Same as the rest of this repo (see `CLAUDE.md`): no `&&` / `|` chaining, no `/tmp`,
+no HEREDOC with `gh`. Run each command as a separate Bash call.
+
+Foreground `sleep` is blocked by the harness, so the CI wait **must** run as a
+background Bash call (`run_in_background: true`). You get one notification when it exits.
+
+## Procedure
+
+### 1. Inspect the PR
+
+```bash
+gh pr view $PR --repo hdknr/blogs --json number,title,state,isDraft,headRefName,mergeable
+```
+
+- `state` is not `OPEN` → report that it is already closed/merged and jump to step 5
+  (cleanup may still be pending).
+- Record `headRefName` — needed to locate the worktree in step 5.
+
+### 2. Make the PR ready (this is what triggers CI)
+
+**If `isDraft` is `true`** — the normal `/blog` case:
+
+```bash
+gh pr ready $PR --repo hdknr/blogs
+```
+
+**If `isDraft` is `false`** — the PR was opened as ready, or commits were pushed after it
+became ready. In both cases `ready_for_review` has not fired for the current head, so no
+run exists for this commit. Re-toggle to fire it:
+
+```bash
+gh pr ready $PR --repo hdknr/blogs --undo
+```
+
+```bash
+gh pr ready $PR --repo hdknr/blogs
+```
+
+> Do not skip the re-toggle on the assumption that "a green check is already there".
+> A check from an earlier commit does not cover the current head.
+
+### 3. Wait for the Link check
+
+Run as a **background** Bash call. The `length > 0` guard is essential: immediately after
+`gh pr ready`, GitHub has not registered the run yet and an unguarded "nothing is pending"
+test would pass instantly.
+
+```bash
+until [ "$(gh pr checks $PR --repo hdknr/blogs --json bucket --jq 'if length > 0 and (all(.[]; .bucket != "pending")) then "done" else "wait" end' 2>/dev/null)" = "done" ]; do sleep 20; done
+```
+
+When the notification arrives, read the result:
+
+```bash
+gh pr checks $PR --repo hdknr/blogs --json name,bucket,link
+```
+
+- every `bucket` is `pass` → continue to step 4
+- any `bucket` is `fail` → **stop.** Report the failing check and its `link` to the user in
+  Japanese, and do not merge. Fixing the failure means pushing a commit and re-running
+  `/ship` (which re-toggles ready and re-fires CI).
+
+### 4. Merge
+
+This repo uses merge commits (see `git log --merges`), not squash:
+
+```bash
+gh pr merge $PR --repo hdknr/blogs --merge --delete-branch
+```
+
+### 5. Remove the worktree
+
+`--force` is required because of untracked files like `pr_body.md` and `pr-url.txt`.
+Resolve the absolute path from `git worktree list` — **do not** construct it from the
+branch name by hand.
+
+```bash
+git worktree list
+```
+
+```bash
+git worktree remove --force "<absolute path matching headRefName>"
+```
+
+If `--delete-branch` in step 4 left a stale local branch, prune it:
+
+```bash
+git worktree prune
+```
+
+### 6. Wiki auto-ingest check
+
+Skip this step entirely if the caller asked to skip Wiki auto-ingest (e.g. `/blog` invoked
+from `scripts/blog-batch.sh`). Bundling wiki commits into blog branches causes conflicts
+when several blog PRs run in parallel.
+
+```bash
+cat .claude/wiki-last-ingest.txt
+```
+
+Count posts in `content/posts/` whose frontmatter `date` is on or after that date
+(default `1970-01-01` if the file is missing).
+
+- **≥ 20 posts** → run `/wiki-ingest all`, then use the Write tool to set
+  `.claude/wiki-last-ingest.txt` to today's date.
+- **< 20 posts** → just report 「あと N 本で Wiki 更新」. Do not run ingest.
+
+## Report to the user
+
+In Japanese, concisely:
+
+- the check result (pass/fail, and which check)
+- the merge commit / PR URL
+- whether the worktree was removed
+- the Wiki ingest decision and the remaining count
+
+If the run stopped at step 3 because CI failed, say so plainly and state that nothing was
+merged.

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,13 +1,30 @@
 name: Link check
 
 on:
+  # PRs are created as DRAFT by the /blog skill and marked ready only when the
+  # post is final, so the internal check runs ONCE per PR — at the moment the PR
+  # becomes mergeable. `synchronize` is deliberately absent: without it, the
+  # intermediate pushes during drafting/review no longer each trigger a full run.
+  #
+  # Consequences to be aware of:
+  #   - A PR opened directly as ready (not draft) fires no run. Toggle it with
+  #     `gh pr ready --undo` then `gh pr ready`, or use workflow_dispatch.
+  #   - Pushing more commits to an ALREADY-ready PR does not re-run the check,
+  #     so its status reflects the commit at ready time. Re-toggle as above.
   pull_request:
+    types: [ready_for_review, reopened]
   push:
     branches: ["main"]
   schedule:
     # Weekly external-link sweep: Monday 00:00 UTC (09:00 JST)
     - cron: "0 0 * * 1"
   workflow_dispatch:
+
+# Safety net for the re-toggle cases above: never let a superseded run keep
+# burning minutes once a newer one starts for the same ref.
+concurrency:
+  group: linkcheck-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Tech blog built with Hugo + PaperMod, hosted on GitHub Pages.
 - `scripts/categorize.py` — automatic category/tag assignment
 - `hugo.toml` — Hugo config
 - `.claude/skills/blog/` — `/blog` skill
+- `.claude/skills/ship/` — `/ship` skill (draft PR → ready → CI → merge → cleanup)
 - `.claude/agents/` — custom specialist agents
 - `.claude/temp/` — scratch dir (gitignored, use instead of `/tmp`)
 - `.worktrees/` — git worktree dir (gitignored, lives outside `.claude/` so it is not flagged as a sensitive file)
@@ -89,6 +90,21 @@ See "コミット・ブランチ・PR 作成" in `.claude/skills/blog/SKILL.md` 
 - Commit message: `Add blog post: <post-title-in-Japanese>`
 - PR title: `Add blog: <post-title-in-Japanese>`
 - When the source is a GitHub URL, append a link back to the source after the PR is created.
+- **Open PRs as drafts** (`gh pr create --draft`). Merges use merge commits (`gh pr merge --merge`), not squash.
+
+## Draft → ready → CI → merge (`/ship`)
+
+`linkcheck.yml` triggers on `pull_request: [ready_for_review, reopened]` — **not** on every
+push. So the internal link check runs once per PR, when the PR becomes mergeable.
+
+- `/blog` creates a **draft** PR and stops there. Follow-up edits are pushed to the same
+  draft branch and fire no CI.
+- `/ship <PR-number>` does ready → wait for Link check → merge (only if green) → remove the
+  worktree → Wiki ingest check.
+- A PR that is already ready needs `gh pr ready --undo` then `gh pr ready` to fire CI for
+  the current head; `/ship` handles this. A green check from an earlier commit does not
+  cover the current head.
+- See `.claude/skills/ship/SKILL.md`.
 
 ## Blog-post status tracking (🚀 reaction convention)
 


### PR DESCRIPTION
## 背景

PR #599 で `Link check` が 3 回走った。3 回の push（初回 + ユーザー依頼による追記 2 回）それぞれが `on: pull_request` を発火させ、しかも `concurrency` 設定がないため、後続に上書きされた古い run もキャンセルされず完走していた。

レビュー中の中間 push で毎回フルの CI を回すのは無駄なので、**マージ可能になった時点で 1 回だけ**走る形に変える。

## 変更内容

### 1. `linkcheck.yml` — トリガーを絞る

```yaml
pull_request:
  types: [ready_for_review, reopened]
```

`synchronize` を意図的に外した。Draft のまま push しても CI は走らず、Ready にした瞬間に 1 回走る。

保険として `concurrency` も追加した（後述の re-toggle で新しい run が始まったとき、古い run を止めるため）。

```yaml
concurrency:
  group: linkcheck-${{ github.ref }}
  cancel-in-progress: true
```

### 2. `/blog` — Draft PR で作って止まる

- `gh pr create` に `--draft` を追加
- 「Post-merge follow-up」節（worktree 削除・Wiki ingest 判定）を削除し、`/ship` への引き継ぎに置き換え
- `/blog` の責務は「Draft PR 作成 + 🚀 付与」までになった

### 3. `/ship` — 新スキル

`.claude/skills/ship/SKILL.md`。`/ship <PR番号>` で以下を一連実行する。

1. PR の状態確認（`isDraft` / `headRefName`）
2. Ready にする（＝ CI 発火）
3. Link check の完了待ち（バックグラウンド実行）
4. **green のときだけ** `gh pr merge --merge --delete-branch`
5. worktree を `--force` 削除
6. Wiki ingest 判定（20 本閾値）

### 4. `CLAUDE.md`

Branch / PR conventions に Draft 前提とマージ方式（merge commit）を明記し、`Draft → ready → CI → merge` 節を追加。

## 設計上の注意点（ワークフローと CLAUDE.md にコメントとして記載）

`ready_for_review` は「Ready になった瞬間」にしか発火しないため、次の 2 ケースで run が存在しない状態になる。

- **Ready で直接作られた PR** — `opened` を types に入れれば拾えるが、Draft 作成時にも `opened` は発火するので今回の目的（中間 push で走らせない）と衝突する。よって types には入れず、`gh pr ready --undo` → `gh pr ready` の re-toggle で対応する。
- **すでに Ready の PR に追加 push した場合** — チェックの状態は Ready 時点のコミットのものになる。古いコミットの green は現在の HEAD を保証しない。

`/ship` は `isDraft` が `false` のときに自動で re-toggle するので、通常はユーザーが意識する必要はない。

なお `main` にブランチ保護は設定されていないため（`gh api .../protection` が 404）、必須チェック未実行でマージがブロックされる詰まりは発生しない。マージのゲートは `/ship` のステップ 4 が担う。

## 検証

- `linkcheck.yml` / `ship/SKILL.md` を YAML パースして構文とキーを確認
- トリガー `["pull_request", "push", "schedule", "workflow_dispatch"]`、`pull_request.types == ["ready_for_review", "reopened"]`、`concurrency.cancel-in-progress == true` を確認

この PR 自体は Ready で作成されるため CI は自動発火しない。`/ship` で Ready を re-toggle すれば発火する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
