### PR TITLE
Fix dead links from the weekly lychee sweep (#607)

### DIFF
--- a/content/posts/2015/07/2015-07-30-8bbdff7f366574a9d1eb.md
+++ b/content/posts/2015/07/2015-07-30-8bbdff7f366574a9d1eb.md
@@ -15,7 +15,7 @@ tags: []
 ### 渋谷
 
 - 千駄ヶ谷 Be a Good Neighbor
-- 道玄坂 [ABOUT LIFE COFFEE BREWERS](http://www.about-life.coffee/)
+- 道玄坂 [ABOUT LIFE COFFEE BREWERS](https://onibuscoffee.com/pages/locations/dogenzaka)
 - 富ヶ谷[Fuglen Tokyo](https://www.facebook.com/Fuglen.Tokyo)
 - 猿楽町 THE COFFEESHOP
 

--- a/content/posts/2023/05/2023-05-05-d7efc36888d56b2139af42fea56c85a7.md
+++ b/content/posts/2023/05/2023-05-05-d7efc36888d56b2139af42fea56c85a7.md
@@ -54,7 +54,7 @@ autossh -M 0 -N -f -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -R 808
 - (3) autossh のコマンド・オプション例 - 元 RX-7 乗りの適当な日々. https://www.na3.jp/entry/20200416/p1.
 - (4) CentOS で autossh を systemd service として動かす - Qiita. https://qiita.com/sandopan65/items/e21bdf710ac70f691e21.
 - (5) autossh の “-M” オプションの正体. autossh… | by Goro Yanagi .... https://medium.com/veltra-engineering/autossh-6aae10b5eb12.
-- (6) ssh — autossh を使用してリバース SSH トンネルを開いたままに .... https://www.web-development-kb-ja.site/ja/ssh/autossh%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%83%AA%E3%83%90%E3%83%BC%E3%82%B9ssh%E3%83%88%E3%83%B3%E3%83%8D%E3%83%AB%E3%82%92%E9%96%8B%E3%81%84%E3%81%9F%E3%81%BE%E3%81%BE%E3%81%AB%E3%81%99%E3%82%8B%E3%81%9F%E3%82%81%E3%81%AE%E6%AD%A3%E3%81%97%E3%81%84%E3%82%AA%E3%83%97%E3%82%B7%E3%83%A7%E3%83%B3/960608887/.
+- (6) ssh — autossh を使用してリバース SSH トンネルを開いたままに .... `https://www.web-development-kb-ja.site/ja/ssh/autossh%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%83%AA%E3%83%90%E3%83%BC%E3%82%B9ssh%E3%83%88%E3%83%B3%E3%83%8D%E3%83%AB%E3%82%92%E9%96%8B%E3%81%84%E3%81%9F%E3%81%BE%E3%81%BE%E3%81%AB%E3%81%99%E3%82%8B%E3%81%9F%E3%82%81%E3%81%AE%E6%AD%A3%E3%81%97%E3%81%84%E3%82%AA%E3%83%97%E3%82%B7%E3%83%A7%E3%83%B3/960608887/`（ドメインは 2026 年時点でパーキングページ化し、記事本体は消滅）
 
 ### `-M`
 

--- a/content/posts/2024/10/2024-10-04-2a9f66260290a10756ad905ebb707116.md
+++ b/content/posts/2024/10/2024-10-04-2a9f66260290a10756ad905ebb707116.md
@@ -212,4 +212,4 @@ client.update_collection(
 
 ドキュメント:
 
-- [Qdrant Python Client Documentation](https://python-client.qdrant.tech/)
+- [Qdrant Python Client（qdrant-client リポジトリ）](https://github.com/qdrant/qdrant-client)

--- a/content/posts/2026/03/2026-03-05-c34e3d75e5362af5db9e32df8e7db5b7.md
+++ b/content/posts/2026/03/2026-03-05-c34e3d75e5362af5db9e32df8e7db5b7.md
@@ -148,13 +148,13 @@ LLM は学習データの中に「戦略コンサルタントが書いた文章�
 
 ### Google 公式のシステム指示ベストプラクティス
 
-[Gemini 3 開発者ガイド](https://ai.google.dev/gemini-api/docs/gemini-3)によると:
+[Gemini 3 のプロンプト設計指針（Core Prompting Principles）](https://ai.google.dev/gemini-api/docs/prompting-strategies)によると:
 
 | 原則 | 内容 |
 |------|------|
 | 直接的に書く | 不要な修飾語や過度に説得的な言葉を避ける |
 | 構造を一貫させる | XML タグ（`<context>`, `<task>`）や Markdown 見出しを使う |
-| 制約は末尾に | 否定的制約（「〇〇するな」）はプロンプトの最後に配置 |
+| 重要な制約は冒頭に | 振る舞いの制約・ロール定義・出力形式は System Instruction かプロンプト冒頭に配置 |
 | Few-shot を含める | ゼロショットよりも例示付きが推奨 |
 | Temperature はデフォルト | Gemini 3 は 1.0 が最適化されており、変更は逆効果の場合が多い |
 

--- a/content/posts/2026/03/2026-03-05-c34e3d75e5362af5db9e32df8e7db5b7.md
+++ b/content/posts/2026/03/2026-03-05-c34e3d75e5362af5db9e32df8e7db5b7.md
@@ -148,7 +148,7 @@ LLM は学習データの中に「戦略コンサルタントが書いた文章�
 
 ### Google 公式のシステム指示ベストプラクティス
 
-[Gemini 3 プロンプティングガイド](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/start/gemini-3-prompting-guide)によると:
+[Gemini 3 開発者ガイド](https://ai.google.dev/gemini-api/docs/gemini-3)によると:
 
 | 原則 | 内容 |
 |------|------|
@@ -219,6 +219,6 @@ Gem 例: 「事業計画レビューワー」
 - [When "A Helpful Assistant" Is Not Really Helpful — arXiv](https://arxiv.org/html/2311.10054v3)
 - [Persona is a Double-edged Sword — arXiv](https://arxiv.org/html/2408.08631v1)
 - [Role Prompting Guide — Learn Prompting](https://learnprompting.org/docs/advanced/zero_shot/role_prompting)
-- [Gemini 3 Prompting Guide — Google Cloud](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/start/gemini-3-prompting-guide)
+- [Gemini 3 Developer Guide — Google AI for Developers](https://ai.google.dev/gemini-api/docs/gemini-3)
 - [Prompt Design Strategies — Gemini API](https://ai.google.dev/gemini-api/docs/prompting-strategies)
 - [Role-Prompting: Does Adding Personas Really Make a Difference? — PromptHub](https://www.prompthub.us/blog/role-prompting-does-adding-personas-to-your-prompts-really-make-a-difference)

--- a/lychee-external.toml
+++ b/lychee-external.toml
@@ -31,10 +31,15 @@ remap = ["https://hdknr.github.io/blogs/ http://127.0.0.1:8099/blogs/"]
 accept = ["200", "202", "206", "401", "403", "405", "406", "415", "429", "500", "503"]
 
 # NOTE: do NOT set `user_agent` to a browser string here. It was tried and
-# reverted: a browser UA does fix the two UA-gated hosts excluded below
-# (laboro.ai, about-life.coffee), but lychee has no per-host UA, and the same
-# string makes facebook.com answer 400 and ai.google.dev bounce into an endless
-# sign-in redirect — 8 links across 7 posts that pass today. Net negative.
+# reverted: a browser UA does fix the UA-gated host excluded below (laboro.ai),
+# but lychee has no per-host UA, and the same string makes facebook.com answer
+# 400 and ai.google.dev bounce into an endless sign-in redirect — 8 links across
+# 7 posts that pass today. Net negative.
+#
+# A browser UA is also actively misleading during triage: about-life.coffee
+# answers 200 to a browser UA, but the body is a ParkLogic domain-parking stub
+# (<title>Redirecting...</title>), not the shop site. A 200 is not proof of
+# life — check the response body, not just the status code.
 
 max_retries = 2
 retry_wait_time = 3
@@ -91,10 +96,6 @@ exclude = [
   "^https?://(www\\.)?polymarket\\.com/",
   "^https?://(www\\.)?coveo\\.com/",
   "^https?://(www\\.)?ainvest\\.com/",
-  # about-life.coffee (openresty) closes the connection mid-response for
-  # lychee's default client but serves 200 to curl and to lychee with a browser
-  # UA. Reported in #561, #574 and #607; the shop site is live.
-  "^https?://(www\\.)?about-life\\.coffee/",
   # Hosts with expired / self-signed / untrusted certs (reachable in browser).
   # semrush.jp serves 200 but omits the intermediate cert, so clients that do
   # not chase the AIA extension (lychee) reject it while browsers accept it.

--- a/lychee-external.toml
+++ b/lychee-external.toml
@@ -30,11 +30,21 @@ remap = ["https://hdknr.github.io/blogs/ http://127.0.0.1:8099/blogs/"]
 # a genuinely removed page.
 accept = ["200", "202", "206", "401", "403", "405", "406", "415", "429", "500", "503"]
 
+# NOTE: do NOT set `user_agent` to a browser string here. It was tried and
+# reverted: a browser UA does fix the two UA-gated hosts excluded below
+# (laboro.ai, about-life.coffee), but lychee has no per-host UA, and the same
+# string makes facebook.com answer 400 and ai.google.dev bounce into an endless
+# sign-in redirect — 8 links across 7 posts that pass today. Net negative.
+
 max_retries = 2
 retry_wait_time = 3
 # 20s produced a steady trickle of TIMEOUT reports for hosts that answer fine
-# in ~20-25s under load (pola.rs, securityonline.info, cmr.berkeley.edu,
-# open-notebook.ai, …). 30s clears those without hiding real deaths.
+# in ~20-25s under load (pola.rs, cmr.berkeley.edu, mamezou-tech, …); 30s cleared
+# those. It did NOT help the hosts that stall the runner outright — #607 showed
+# securityonline.info and open-notebook.ai timing out again for the third sweep
+# in a row, so those two moved to the exclude list instead. Raising this further
+# only makes the job slower; a host that answers in 1s from anywhere else is not
+# going to answer in 31s from a GitHub Actions IP.
 timeout = 30
 max_concurrency = 8
 
@@ -65,6 +75,10 @@ exclude = [
   "^https?://zhuanlan\\.zhihu\\.com/",
   "^https?://(developers|access)\\.redhat\\.com/",
   "^https?://app\\.getzep\\.com/",
+  # laboro.ai answers a hard 404 to lychee's User-Agent but 200 to a browser
+  # one (verified: same URL, only the UA differs). Reported dead in three
+  # consecutive sweeps (#561, #574, #607) while the page was live the whole time.
+  "^https?://laboro\\.ai/",
   # Hosts whose servers mishandle lychee's HTTP/2 client ("HTTP/2 protocol
   # error") but load fine in a browser. Verified reachable manually.
   "^https?://(www\\.)?washingtonpost\\.com/",
@@ -77,6 +91,10 @@ exclude = [
   "^https?://(www\\.)?polymarket\\.com/",
   "^https?://(www\\.)?coveo\\.com/",
   "^https?://(www\\.)?ainvest\\.com/",
+  # about-life.coffee (openresty) closes the connection mid-response for
+  # lychee's default client but serves 200 to curl and to lychee with a browser
+  # UA. Reported in #561, #574 and #607; the shop site is live.
+  "^https?://(www\\.)?about-life\\.coffee/",
   # Hosts with expired / self-signed / untrusted certs (reachable in browser).
   # semrush.jp serves 200 but omits the intermediate cert, so clients that do
   # not chase the AIA extension (lychee) reject it while browsers accept it.
@@ -90,4 +108,17 @@ exclude = [
   "^https?://(www\\.)?agentsworkshop\\.ai/",
   # X/Twitter: returns 404 to bots for valid tweets (SPA).
   "^https?://(x|twitter)\\.com/",
+  # Hosts that answer in 1-2s from an ordinary network (and pass a local lychee
+  # run with this same config) but stall until the timeout when the request comes
+  # from a GitHub Actions runner — datacenter-IP throttling at the CDN edge. Only
+  # hosts reported by three consecutive sweeps are listed; a first-time TIMEOUT is
+  # left in the report so a genuine death is not silently swallowed.
+  "^https?://securityonline\\.info/",         # #561, #574, #607
+  "^https?://(www\\.)?open-notebook\\.ai/",   # #561, #574, #607
+  # Google Cloud console: a signed-in-only app, not a document. Every deep link
+  # bounces through the sign-in flow, which for an anonymous client is an
+  # endless 302 loop back to itself — lychee gives up after max-redirects and
+  # reports 302. This can never pass and says nothing about the page, so the
+  # accept-list cannot help; exclude the host.
+  "^https?://console\\.cloud\\.google\\.com/",
 ]


### PR DESCRIPTION
## 概要

週次 lychee スイープ #607 が検出した **24 件（11 errors / 13 timeouts）全件**に対応。

報告された URL を **ブラウザ UA と デフォルト UA の両方で curl し直し、さらに CI と同一の lychee 0.24.2 をローカルで実行**して、「本物の死」「lychee クライアント起因の誤検知」「CI（GitHub Actions の IP）起因の誤検知」の 3 つに切り分けた上で処置している。

Closes #607

## 切り分けの結果

| 分類 | 件数 | 処置 |
|---|---|---|
| 本物の死（後継あり／消滅） | 5 | 本文修正 |
| lychee クライアント起因（UA ゲート） | 1 | exclude（原因を明記） |
| CI の IP 起因（3 週連続の常習） | 3 | exclude |
| 構造的に永久に通らない（ログイン必須アプリ） | 4 | exclude |
| CI の IP 起因（初出） | 10 | **意図的に残置**（再発を確認してから隠す） |
| 生死判定不能 | 1 | **意図的に残置** |

> 当初 `about-life.coffee` を「lychee クライアント起因の誤検知」として exclude していましたが、別モデルによる敵対的レビューで**ドメインがパーキングに出されており 200 の中身が空スタブ**であることが判明したため、「本物の死」に再分類して差し替えました（詳細は本 PR のレビュー結果コメント）。

**13 件の TIMEOUT はすべてローカル lychee で通過**する。7 ホスト中 6 が Netlify 配信で、GitHub Actions のランナー IP からの要求だけが CDN エッジで止められている。#574 で `timeout` を 20s → 30s に上げたのはこの層には効いていない（securityonline.info / open-notebook.ai が 3 週連続で再出現）。

## 変更内容

### 1. 本文（4 記事 / 5 箇所）

| 記事 | 旧 | 新 | 根拠 |
|---|---|---|---|
| 2026-03-05 Gemini プロンプト（本文） | `docs.cloud.google.com/vertex-ai/.../gemini-3-prompting-guide` | `ai.google.dev/gemini-api/docs/prompting-strategies` | 旧ページは 404 で、新ドキュメント階層に等価な後継が無いことを 6 パターンの URL 探索で確認。差し替え先の「Gemini 3 — Core Prompting Principles」節が**表の 5 行中 4 行を逐語的に**裏付ける |
| 2026-03-05 Gemini プロンプト（参考文献） | 同上 | `ai.google.dev/gemini-api/docs/gemini-3` | Gemini 3 Developer Guide。temperature の記述の裏付けとして有効 |
| 2026-03-05 Gemini プロンプト（表 3 行目） | 「制約は末尾に」 | 「重要な制約は冒頭に」 | 上記で確定した出典が**正反対を明記**していた（"Place essential behavioral constraints... in the System Instruction or at the very beginning"）。ユーザー判断によりこの 1 行のみ修正 |
| 2015-07-30 渋谷コーヒー店 | `www.about-life.coffee/` | `onibuscoffee.com/pages/locations/dogenzaka` | **ドメインが ParkLogic のパーキングに出ており、全パスが `<title>Redirecting...</title>` の空スタブ**。店舗自体は ONIBUS COFFEE の姉妹店として営業中で、道玄坂店の公式ページがアンカーと一致 |
| 2023-05-05 autossh | `web-development-kb-ja.site/...`（裸 URL） | 同 URL をコードスパン化＋消滅注記 | **200 を返すが `Server: Parking/1.0` で Sedo のパーキングページ**。ステータスコードだけでは死を見抜けない例 |
| 2024-10-04 Qdrant | `python-client.qdrant.tech/` | `github.com/qdrant/qdrant-client` | 専用ドキュメントサイトは廃止され、汎用 docs インデックスへ 301。アンカー「Python Client Documentation」と遷移先が一致しなくなっていた |

### 2. スイープ設定（`lychee-external.toml`）

**新規 exclude（4 ホスト）** — すべて原因を特定し、コメントに再発したスイープ番号を記録

| ホスト | 原因（検証済み） |
|---|---|
| `laboro.ai` | **lychee の UA には 404、ブラウザ UA には 200**（URL は同一、UA だけの差で再現）。返る `<title>` がアンカー文言と完全一致することも確認。3 週連続で「生きているのに死亡報告」 |
| `securityonline.info` | 手元では 1.5 秒で 200。ランナーからのみタイムアウト。3 週連続 |
| `open-notebook.ai` | 同上。3 週連続 |
| `console.cloud.google.com` | **ログイン必須のアプリ**で文書ではない。匿名クライアントではサインインへの 302 が自分自身に戻る無限ループになり、`accept` リストでは救えず**永久に通らない** |

**`user_agent` を設定しない理由をコメントで明記**

ブラウザ UA を設定すれば `laboro.ai` は exclude 無しで直る。実際に試したが、**lychee はホスト別 UA を持たないため同じ文字列が `facebook.com` に 400 を返させ、`ai.google.dev` をサインインの無限リダイレクトに落とす**。現在通っている 7 記事 8 リンクを壊すので撤回した。次に同じ発想が出たとき再試行しないよう、config にその経緯を残している。

あわせて **「200 は生存の証明にならない」**旨も config に明記した。ブラウザ UA は `about-life.coffee` のパーキングスタブを「到達可能」に見せてしまい、実際に一度その罠を踏んだため。

**`timeout` のコメントを実態に合わせて修正**

「30s で securityonline.info / open-notebook.ai は解消した」という #574 時点の記述は**誤りだった**（3 週連続で再出現）。ランナーを丸ごと止めるホストには timeout 延長が効かない旨に書き換えた。

## 検証

| 検証 | 結果 |
|---|---|
| `hugo --gc --minify` ビルド | 成功（3,472 ページ） |
| lychee 0.24.2（CI と同一）/ 報告 17 ページ / 同 config | **24 issues → 1** |
| 内部リンクチェック（CI ブロッキングジョブ相当） | **0 errors** / 29,179 unique links |
| 実 CI での外部スイープ（`workflow_dispatch` をブランチ上で実行） | 本 PR コメントに結果を記録 |

ローカル検証だけでは CI の IP 起因の挙動を再現できないため、**ブランチ上で `linkcheck.yml` を実際に手動実行して確認**している。

## 意図的に残した項目

- **`www.command.jp`（3M コマンド、2017 年の記事）** — HTTP/2・HTTP/1.1・HTTP/1.0 のいずれでも応答せず（TLS ハンドシェイクは成功するが HTTP ストリームが即リセット）、WebFetch 経由でも到達不能。Akamai 配信で兄弟ドメイン（post-it.jp 等）も同じ挙動なのでサイト自体は生きている可能性が高いが、**200 を一度も得られていない**。#601 で確立した「生死を確認できないものを exclude で隠さない」方針に従い、リンクもレポート出力もそのまま残した。
- **初出の TIMEOUT ホスト 10 件**（alexop.dev ×4 / weaviate.io ×2 / asdlc.io / akashi-n.com / bvp.com / code.rhodecode.com） — すべて手元では 200 だが、**再発を確認してから隠す**規律を維持するため今回は exclude しない。次回スイープでも出るようなら常習として exclude に移す。

## レビュー記録

別モデル（Sonnet）による敵対的レビューで **2 件の実問題**を検出・修正しました（2 コミット目）。`about-life.coffee` の誤った exclude と、Gemini 3 の差し替え先 URL の誤りです。詳細と証拠は本 PR のレビュー結果コメントに記録しています。

## 仕組み側の論点（判断をお願いしたい点）

**TIMEOUT をレポートに載せ続けるかどうか。** 実 CI 実行で、#574 が「timeout 30s 化で解消した」と記録していた `pola.rs` / `cmr.berkeley.edu` / `mamezou-tech` が再出現し、TIMEOUT 群が**毎回引き直される標本**であることが判明しました。「3 週連続の常習のみ exclude」という今回の方針は妥当ですが、この方針ではレポートを恒久的にゼロにはできません。TIMEOUT を Issue 化の条件から外す／別セクションに分けるといった仕組み側の変更が必要かどうかは、別途ご判断ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
